### PR TITLE
docs: sync stale references after v0.3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PipelineHealer
 
-<!-- LAST_VERIFIED: db5ad51 -->
+<!-- LAST_VERIFIED: 9daf25e -->
 
 > Policy-aware CI/CD remediation platform for GitHub Actions failures.
 
@@ -30,27 +30,26 @@ CI failures create repetitive triage work. PipelineHealer shortens time-to-under
 
 This repository started as a hackathon submission baseline and continues as an actively maintained open-source release line.
 
-## Current Release Baseline (v0.2.11)
+## Current Release Baseline (v0.3.0)
 
-- Release baseline: [`v0.2.11`](https://github.com/Canepro/pipelinehealer/releases/tag/v0.2.11)
+- Release baseline: [`v0.3.0`](https://github.com/Canepro/pipelinehealer/releases/tag/v0.3.0)
 - Historical submission baseline: `v0.2.9`
 - Deployment model: Azure-first, using immutable release images (`bash scripts/ph.sh deploy:release --release-version vX.Y.Z`)
 - Operator docs: `docs/DEMO_SCRIPT.md`, `docs/LOCAL_DEMO_RUNBOOK.md`, `docs/RELEASE_RUNBOOK.md`
+- Next target: `v0.3.1` integration scope ([#44](https://github.com/Canepro/pipelinehealer/issues/44))
 
 ## Kubernetes Install Status (Important)
 
-As of **February 23, 2026**, Kubernetes/Helm setup exists, but random-user "clone + helm install" is **not yet guaranteed** in every environment.
+As of **March 3, 2026** (`v0.3.0`), release publishing now enforces anonymous pullability checks for:
+- backend/frontend image tags (`vX.Y.Z` and `X.Y.Z`)
+- backend/frontend image digests
+- Helm chart OCI tag (`X.Y.Z`)
 
-Why:
-- image pull success depends on registry/package accessibility from cluster nodes
-- Helm can report `STATUS: deployed` while pods still fail to start
+This closes the previous random-user portability regression tracked in [#37](https://github.com/Canepro/pipelinehealer/issues/37) (now closed), where Helm could report `deployed` while pods still failed with `ErrImagePull` (`401`/`403`).
 
-What failure looks like:
-- pod status: `ErrImagePull` / `ImagePullBackOff`
-- pod events: registry token failures like `401 Unauthorized` or `403 Forbidden`
-
-Treat Kubernetes as random-user-ready only after the pullability gate in `docs/KUBERNETES_HELM_RUNBOOK.md` passes on a clean cluster.
-Tracking issue: [#37](https://github.com/Canepro/pipelinehealer/issues/37).
+Still recommended for operators:
+- prefer published release tags over local ad-hoc images for shared/public installs
+- run the pullability gate in release verification before claiming clean-cluster portability
 
 ### Evidence from a real incident
 

--- a/docs/AGENT_HANDOFF_CONTEXT_MINISPEC.md
+++ b/docs/AGENT_HANDOFF_CONTEXT_MINISPEC.md
@@ -1,8 +1,8 @@
 # Agent Handoff + Copy Context Mini-Spec
 
-<!-- LAST_VERIFIED: 44effc3 -->
+<!-- LAST_VERIFIED: 9daf25e -->
 
-Status: Phase 1 implemented in working branch (`Copy Context` + disabled `Assign to Agent`), Phase 2 pending
+Status: Phase 0/1 released in `v0.3.0` (`Copy Context` + disabled `Assign to Agent`), Phase 2 pending (`v0.3.1`)
 Owner: PipelineHealer maintainers
 Scope target:
 - `v0.3.0`: `Copy Context` + disabled `Assign to Agent` `Coming Soon` affordance

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,6 +1,6 @@
 # PipelineHealer CLI Reference
 
-<!-- LAST_VERIFIED: b20f2a6 -->
+<!-- LAST_VERIFIED: 9daf25e -->
 
 Canonical reference for `scripts/ph.sh` — the one-command operator interface for PipelineHealer.
 

--- a/docs/FUTURE_PLAN.md
+++ b/docs/FUTURE_PLAN.md
@@ -1,6 +1,6 @@
 # Future Plan (Versioned Roadmap)
 
-<!-- LAST_VERIFIED: a437be5 -->
+<!-- LAST_VERIFIED: 9daf25e -->
 
 This roadmap is version-driven. Backlog work is planned against target releases, not ad-hoc phases.
 
@@ -36,6 +36,7 @@ This roadmap is version-driven. Backlog work is planned against target releases,
 | `v0.2.9` | Released | GH-AW/MCP hybrid diagnostics mode + passive backfill matching reliability hardening |
 | `v0.2.10` | Released | Settings persistence safety hardening (`PH_ALLOWED_REPOS` mutation safety + URL guardrails) |
 | `v0.2.11` | Released | Runtime control-surface separation + canary policy hardening + Kubernetes pullability docs clarity |
+| `v0.3.0` | Released | Activity Detail AI handoff UX baseline (`Copy Context` + disabled `Assign to Agent`) + anonymous GHCR pullability gate hardening |
 
 ## Released Target: `v0.2.6` (Verification Learning + Diagnostics Signal Clarity)
 
@@ -192,11 +193,11 @@ Theme: separate runtime execution controls cleanly for operators and close remai
 3. Kubernetes portability docs clearly block false "Helm deployed = working" conclusions.
 4. Updated tests pass for settings persistence and remediation dry-run behavior.
 
-## Active Target: `v0.3.0` (Minor)
+## Released Target: `v0.3.0` (Minor)
 
 Theme: operator handoff UX baseline + Kubernetes portability release hardening.
 
-### Must-Have Scope
+### Delivered Scope
 
 1. Activity Detail copy-handoff baseline (`BL-038`)
    - Add `Copy Context` action with bounded, redacted payload output.
@@ -216,11 +217,11 @@ Theme: operator handoff UX baseline + Kubernetes portability release hardening.
 4. No regressions in existing Activity Detail actions (`Retry`, `Backfill Diagnostics`).
 5. Release docs and changelog match shipped behavior.
 
-## Planned Target: `v0.3.1` (Minor)
+## Active Target: `v0.3.1` (Minor)
 
 Theme: integration activation for non-GitHub CI ingestion and agent handoff.
 
-### Planned Scope
+### Must-Have Scope
 
 1. Jenkins bridge ingestion (`BL-034`)
    - Add signed ingestion path for external CI failures (Jenkins) into PipelineHealer activity pipeline.
@@ -407,12 +408,12 @@ These items are researched and tracked; some have scoped phased rollout while ot
 | `BL-033` | Multi-platform notifications research track: Slack/Teams/Rocket.Chat delivery model for non-admin stakeholders with auditable outbound events | `TBD (post-submission)` | minor | Medium | Research / Undecided |
 | `BL-034` | Jenkins bridge ingestion path: signed external CI failure payload -> synthetic PipelineHealer activity (`source_selection_path=jenkins_bridge`) with issue-first defaults | `v0.3.1` | minor | High | Planned |
 | `BL-035` | Native Jenkins provider adapter: deeper job metadata/log/artifact retrieval + rerun/governance parity with existing provider model | `v0.5.x` | minor | Medium | Queued |
-| `BL-036` | Public distribution hardening for Kubernetes portability: publish anonymous-pull image path and add clean-cluster pullability gate in release verification to block `ErrImagePull` (`401`/`403`) regressions ([#37](https://github.com/Canepro/pipelinehealer/issues/37)) | `v0.3.0` | patch | High | In progress (working branch) |
+| `BL-036` | Public distribution hardening for Kubernetes portability: publish anonymous-pull image path and add clean-cluster pullability gate in release verification to block `ErrImagePull` (`401`/`403`) regressions ([#37](https://github.com/Canepro/pipelinehealer/issues/37)) | `v0.3.0` | patch | High | Completed (released in `v0.3.0`) |
 | `BL-037` | Settings persistence safety hardening: prevent accidental `PH_ALLOWED_REPOS` truncation via additive/remove semantics in `scripts/ph.sh` with explicit replace mode, plus backend URL resolution guardrails ([#38](https://github.com/Canepro/pipelinehealer/issues/38)) | `v0.2.10` | patch | High | Completed (released in `v0.2.10`) |
-| `BL-038` | Activity Detail one-click `Copy Context` for AI-ready handoff payloads with bounded size + redaction, plus disabled `Assign to Agent` `Coming Soon` affordance ([#41](https://github.com/Canepro/pipelinehealer/issues/41)) | `v0.3.0` | patch | High | In progress (working branch) |
+| `BL-038` | Activity Detail one-click `Copy Context` for AI-ready handoff payloads with bounded size + redaction, plus disabled `Assign to Agent` `Coming Soon` affordance ([#41](https://github.com/Canepro/pipelinehealer/issues/41)) | `v0.3.0` | patch | High | Completed (released in `v0.3.0`) |
 | `BL-039` | Activity Detail `Assign to Agent` integration (`copy_only` + optional `webhook`) with audit-safe handoff controls ([#42](https://github.com/Canepro/pipelinehealer/issues/42)) | `v0.3.1` | minor | Medium | Planned |
-| `BL-040` | Release umbrella tracking for bundled `v0.3.0` scope (`BL-036`, `BL-038`) ([#43](https://github.com/Canepro/pipelinehealer/issues/43)) | `v0.3.0` | patch | High | Tracking |
-| `BL-041` | Release umbrella tracking for bundled `v0.3.1` integration scope (`BL-034`, `BL-039`) ([#44](https://github.com/Canepro/pipelinehealer/issues/44)) | `v0.3.1` | patch | High | Tracking |
+| `BL-040` | Release umbrella tracking for bundled `v0.3.0` scope (`BL-036`, `BL-038`) ([#43](https://github.com/Canepro/pipelinehealer/issues/43)) | `v0.3.0` | patch | High | Completed (released in `v0.3.0`) |
+| `BL-041` | Release umbrella tracking for bundled `v0.3.1` integration scope (`BL-034`, `BL-039`) ([#44](https://github.com/Canepro/pipelinehealer/issues/44)) | `v0.3.1` | patch | High | Tracking (active) |
 
 ## Definition of Done (Per Version)
 

--- a/docs/HACKATHON_LOG.md
+++ b/docs/HACKATHON_LOG.md
@@ -1,6 +1,6 @@
 # PipelineHealer Hackathon Log
 
-**Last updated:** March 2, 2026
+**Last updated:** March 3, 2026
 
 This is the long-form project tracker for hackathon execution status, submission readiness, and milestone history.
 
@@ -30,7 +30,12 @@ This is the long-form project tracker for hackathon execution status, submission
 - Release planning split is active:
   - `v0.3.0` scope tracking issue: [#43](https://github.com/Canepro/pipelinehealer/issues/43) (`BL-036` + `BL-038`)
   - `v0.3.1` scope tracking issue: [#44](https://github.com/Canepro/pipelinehealer/issues/44) (`BL-034` + `BL-039`)
-- Release `v0.2.11` is the current public baseline; submission freeze remains active (bugfix/docs/housekeeping only)
+- Release `v0.3.0` is the current public baseline; `v0.3.1` is now the active integration target
+- `v0.3.0` release hardening + AI-handoff UX baseline shipped:
+  - release published: `https://github.com/Canepro/pipelinehealer/releases/tag/v0.3.0`
+  - portability gap issue [#37](https://github.com/Canepro/pipelinehealer/issues/37) closed
+  - handoff UX issue [#41](https://github.com/Canepro/pipelinehealer/issues/41) closed
+  - release umbrella issue [#43](https://github.com/Canepro/pipelinehealer/issues/43) closed
 - MCP observability upgraded: real per-call tool invocation counting, aggregate MCP latency, and enriched action-audit fields (`provider`, `latency_ms`, `success`, `error_class`); read-only runbook context retrieval (`fetch_runbook_context`) now adds `knowledge-mcp` evidence when available
 - Control Center governance route added: `/app/control-center` provides read-only runtime/auth/provider posture, MCP policy-effect matrix, and centralized audit timeline
 - Settings audit UX reworked: audit/trace now lives only in Control Center as a single governance source

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Docs Index
 
-<!-- LAST_VERIFIED: 44effc3 -->
+<!-- LAST_VERIFIED: 9daf25e -->
 
 Use this index to find the right doc quickly.
 
@@ -28,7 +28,7 @@ Use this index to find the right doc quickly.
 ### Tier 3 — Internal/Transient (author discretion; archive post-submission)
 
 - `HACKATHON_LOG.md` — current phase status, submission checklist, and milestone history
-- `FUTURE_PLAN.md` — version-targeted roadmap (current active target: `v0.3.0`; prior submission-readiness patch target closed)
+- `FUTURE_PLAN.md` — version-targeted roadmap (current active target: `v0.3.1`; latest released baseline: `v0.3.0`)
 - `UI_PLAN.md` — UI maturity plan, principles, and weekly tracking through submission
 - `AGENT_HANDOFF_CONTEXT_MINISPEC.md` — draft design for Activity Detail `Copy Context` + optional `Assign to Agent` handoff integration
 - `GH_AW_IMPLEMENTATION_TRACKER.md` — gh-aw research summary, Layer 1/2 checklists, decision log, and evidence

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -1,6 +1,6 @@
 # Release Runbook
 
-<!-- LAST_VERIFIED: b20f2a6 -->
+<!-- LAST_VERIFIED: 9daf25e -->
 
 End-to-end release procedure for PipelineHealer using the repo release helpers.
 


### PR DESCRIPTION
## Summary\n- update README release baseline to v0.3.0 and refresh Kubernetes portability status\n- move roadmap state to v0.3.1 active target and mark v0.3.0 items as released\n- refresh stale docs index/minispec/hackathon log wording and LAST_VERIFIED markers\n\n## Notes\nThis is a docs-only sync pass to remove post-release drift and stale status text.