### PR TITLE
docs: full post-v0.3.0 audit and sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PipelineHealer
 
-<!-- LAST_VERIFIED: 9daf25e -->
+<!-- LAST_VERIFIED: c6e47b9 -->
 
 > Policy-aware CI/CD remediation platform for GitHub Actions failures.
 

--- a/docs/AGENT_HANDOFF_CONTEXT_MINISPEC.md
+++ b/docs/AGENT_HANDOFF_CONTEXT_MINISPEC.md
@@ -1,6 +1,6 @@
 # Agent Handoff + Copy Context Mini-Spec
 
-<!-- LAST_VERIFIED: 9daf25e -->
+<!-- LAST_VERIFIED: c6e47b9 -->
 
 Status: Phase 0/1 released in `v0.3.0` (`Copy Context` + disabled `Assign to Agent`), Phase 2 pending (`v0.3.1`)
 Owner: PipelineHealer maintainers

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # PipelineHealer API Reference
 
-<!-- LAST_VERIFIED: eaa47f7 -->
+<!-- LAST_VERIFIED: c6e47b9 -->
 
 This document describes the PipelineHealer backend REST API, authentication model, request/response contracts, and best practices.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,6 +1,6 @@
 # PipelineHealer CLI Reference
 
-<!-- LAST_VERIFIED: 9daf25e -->
+<!-- LAST_VERIFIED: c6e47b9 -->
 
 Canonical reference for `scripts/ph.sh` — the one-command operator interface for PipelineHealer.
 

--- a/docs/DEMO_SCRIPT.md
+++ b/docs/DEMO_SCRIPT.md
@@ -1,6 +1,6 @@
 # PipelineHealer Demo Recording Guide (Single-File Runbook)
 
-<!-- LAST_VERIFIED: eaa47f7 -->
+<!-- LAST_VERIFIED: c6e47b9 -->
 
 Use this as the only doc during recording day. It includes:
 

--- a/docs/FUTURE_PLAN.md
+++ b/docs/FUTURE_PLAN.md
@@ -1,6 +1,6 @@
 # Future Plan (Versioned Roadmap)
 
-<!-- LAST_VERIFIED: 9daf25e -->
+<!-- LAST_VERIFIED: c6e47b9 -->
 
 This roadmap is version-driven. Backlog work is planned against target releases, not ad-hoc phases.
 
@@ -181,7 +181,7 @@ Theme: separate runtime execution controls cleanly for operators and close remai
    - keep `rollout:canary` deterministic with explicit action toggles (issue-only default without retries)
 3. Kubernetes operator clarity
    - highlight GHCR token/visibility failure mode (`ErrImagePull` `401/403`) and required pullability gate before portability claims
-   - track portability risk in issue [#37](https://github.com/Canepro/pipelinehealer/issues/37)
+   - portability risk tracked in issue [#37](https://github.com/Canepro/pipelinehealer/issues/37) (closed in `v0.3.0`)
 4. Regression protection + docs sync
    - add/update tests around settings persistence and orchestration dry-run gating
    - update `README.md`, `docs/API.md`, `docs/CLI.md`, `docs/KUBERNETES_HELM_RUNBOOK.md`, and `docs/features/03-settings-and-policy-controls.md`

--- a/docs/HACKATHON_LOG.md
+++ b/docs/HACKATHON_LOG.md
@@ -88,7 +88,7 @@ This is the long-form project tracker for hackathon execution status, submission
   - operator runbook added (`docs/KUBERNETES_HELM_RUNBOOK.md`)
 - Kubernetes portability gap tracked for open-source adopters:
   - clean-cluster installs can fail with `ErrImagePull` / `ImagePullBackOff` due to registry access constraints
-  - tracking issue: [#37](https://github.com/Canepro/pipelinehealer/issues/37)
+  - tracking issue: [#37](https://github.com/Canepro/pipelinehealer/issues/37) (closed in `v0.3.0`)
 - Settings persistence safety hardening released in `v0.2.10`:
   - `settings:persist` now defaults to non-destructive repo updates (`--repos-add` / `--repos-remove`) with explicit destructive mode (`--repos-replace`)
   - backend URL guardrails prevent malformed persistence targets; tracking issue [#38](https://github.com/Canepro/pipelinehealer/issues/38) is closed

--- a/docs/JENKINS_BRIDGE_TECHNICAL_DESIGN.md
+++ b/docs/JENKINS_BRIDGE_TECHNICAL_DESIGN.md
@@ -1,6 +1,6 @@
 # BL-034 Technical Design: Jenkins Bridge Ingestion
 
-<!-- LAST_VERIFIED: 8662125 -->
+<!-- LAST_VERIFIED: c6e47b9 -->
 
 Status: Draft (design only, no implementation in this document)  
 Backlog: `BL-034`  

--- a/docs/KUBERNETES_HELM_RUNBOOK.md
+++ b/docs/KUBERNETES_HELM_RUNBOOK.md
@@ -1,12 +1,12 @@
 # Kubernetes Helm Runbook
 
-<!-- LAST_VERIFIED: eaa47f7 -->
+<!-- LAST_VERIFIED: c6e47b9 -->
 
 This runbook adds Kubernetes as a secondary deployment target while keeping Azure Container Apps as the default path.
 
 ## Stop: Read This First
 
-This project is open source, but Kubernetes install is **not automatically random-user-ready** in all environments yet.
+This project is open source, and release portability is validated via anonymous-pullability gates at release time.
 
 Do not treat Helm success output by itself as deployment success. `helm upgrade --install` can return `deployed` while workloads fail to pull images.
 
@@ -14,7 +14,7 @@ Known failure signatures:
 - Pod status: `ErrImagePull` / `ImagePullBackOff`
 - Pod events with registry token failures (`401 Unauthorized`, `403 Forbidden`)
 
-Track status here: [#37](https://github.com/Canepro/pipelinehealer/issues/37)
+Portability hardening tracker [#37](https://github.com/Canepro/pipelinehealer/issues/37) is closed in `v0.3.0`.
 
 ## Scope
 

--- a/docs/LEARNING_SYSTEM_PLAN.md
+++ b/docs/LEARNING_SYSTEM_PLAN.md
@@ -1,6 +1,6 @@
 # Learning System Plan
 
-<!-- LAST_VERIFIED: eaa47f7 -->
+<!-- LAST_VERIFIED: c6e47b9 -->
 
 This document explains the learning/governance subsystem, how to use it today, and what is planned next.
 

--- a/docs/LOCAL_DEMO_RUNBOOK.md
+++ b/docs/LOCAL_DEMO_RUNBOOK.md
@@ -1,6 +1,6 @@
 # Local Demo Runbook (PipelineHealer)
 
-<!-- LAST_VERIFIED: eaa47f7 -->
+<!-- LAST_VERIFIED: c6e47b9 -->
 
 This guide walks you through setting up PipelineHealer locally, triggering CI failures in a demo repo, and verifying the results on the dashboard.
 

--- a/docs/LOGS_AND_INVESTIGATION.md
+++ b/docs/LOGS_AND_INVESTIGATION.md
@@ -1,6 +1,6 @@
 # Logs And Investigation Guide
 
-<!-- LAST_VERIFIED: eaa47f7 -->
+<!-- LAST_VERIFIED: c6e47b9 -->
 
 Use this guide to debug PipelineHealer behavior quickly in local, Docker, and Azure runs.
 

--- a/docs/MODEL_PROVIDER_STRATEGY.md
+++ b/docs/MODEL_PROVIDER_STRATEGY.md
@@ -1,6 +1,6 @@
 # Model Provider Strategy
 
-<!-- LAST_VERIFIED: eaa47f7 -->
+<!-- LAST_VERIFIED: c6e47b9 -->
 
 PipelineHealer is Azure-first today for hackathon delivery and operational simplicity, but is being structured to avoid provider lock-in.
 

--- a/docs/MODEL_PROVIDER_SWITCH_RUNBOOK.md
+++ b/docs/MODEL_PROVIDER_SWITCH_RUNBOOK.md
@@ -1,6 +1,6 @@
 # Model Provider Switch Runbook
 
-<!-- LAST_VERIFIED: eaa47f7 -->
+<!-- LAST_VERIFIED: c6e47b9 -->
 
 This runbook covers safe switching between model providers and fast rollback.
 

--- a/docs/PREDEPLOY_PLACEHOLDER_AUDIT.md
+++ b/docs/PREDEPLOY_PLACEHOLDER_AUDIT.md
@@ -1,6 +1,6 @@
 # Pre-Deploy Placeholder Audit
 
-<!-- LAST_VERIFIED: eaa47f7 -->
+<!-- LAST_VERIFIED: c6e47b9 -->
 
 Use this checklist before `azd up`, before major public demos, and before final submission recording.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Docs Index
 
-<!-- LAST_VERIFIED: 9daf25e -->
+<!-- LAST_VERIFIED: c6e47b9 -->
 
 Use this index to find the right doc quickly.
 

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -1,6 +1,6 @@
 # Release Runbook
 
-<!-- LAST_VERIFIED: 9daf25e -->
+<!-- LAST_VERIFIED: c6e47b9 -->
 
 End-to-end release procedure for PipelineHealer using the repo release helpers.
 

--- a/docs/case-studies/release-tag-mismatch-22163136636.md
+++ b/docs/case-studies/release-tag-mismatch-22163136636.md
@@ -1,6 +1,6 @@
 # Case Study: Release Tag/Version Mismatch (`run #22163136636`)
 
-<!-- LAST_VERIFIED: a13de38 -->
+<!-- LAST_VERIFIED: c6e47b9 -->
 
 ## Summary
 

--- a/docs/features/01-auth-and-access.md
+++ b/docs/features/01-auth-and-access.md
@@ -1,6 +1,6 @@
 # Feature: Auth And Access
 
-<!-- LAST_VERIFIED: eaa47f7 -->
+<!-- LAST_VERIFIED: c6e47b9 -->
 
 This guide explains how users authenticate to PipelineHealer and how admin-only actions are protected.
 

--- a/docs/features/02-diagnosis-and-remediation.md
+++ b/docs/features/02-diagnosis-and-remediation.md
@@ -1,6 +1,6 @@
 # Feature: Diagnosis And Remediation
 
-<!-- LAST_VERIFIED: eaa47f7 -->
+<!-- LAST_VERIFIED: c6e47b9 -->
 
 This guide explains how PipelineHealer moves from failed workflow logs to safe remediation artifacts.
 

--- a/docs/features/03-settings-and-policy-controls.md
+++ b/docs/features/03-settings-and-policy-controls.md
@@ -1,6 +1,6 @@
 # Feature: Settings And Policy Controls
 
-<!-- LAST_VERIFIED: eaa47f7 -->
+<!-- LAST_VERIFIED: c6e47b9 -->
 
 This guide explains runtime controls, persistence behavior, and governance guardrails.
 

--- a/docs/features/04-external-diagnostics-and-mcp.md
+++ b/docs/features/04-external-diagnostics-and-mcp.md
@@ -1,6 +1,6 @@
 # Feature: External Diagnostics And MCP
 
-<!-- LAST_VERIFIED: eaa47f7 -->
+<!-- LAST_VERIFIED: c6e47b9 -->
 
 This guide explains how PipelineHealer ingests external findings and how GitHub MCP is selected, gated, and verified in real runs.
 

--- a/docs/features/05-explainability-and-observability.md
+++ b/docs/features/05-explainability-and-observability.md
@@ -1,6 +1,6 @@
 # Feature: Explainability And Observability
 
-<!-- LAST_VERIFIED: eaa47f7 -->
+<!-- LAST_VERIFIED: c6e47b9 -->
 
 This guide explains where to see evidence, model path telemetry, and confidence attribution for each activity.
 

--- a/docs/features/06-operations-and-deploy.md
+++ b/docs/features/06-operations-and-deploy.md
@@ -1,6 +1,6 @@
 # Feature: Operations And Deployment
 
-<!-- LAST_VERIFIED: eaa47f7 -->
+<!-- LAST_VERIFIED: c6e47b9 -->
 
 This guide explains day-to-day operations: local bring-up, Azure deploy, verification, and safe rollout.
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -1,6 +1,6 @@
 # Feature Guides
 
-<!-- LAST_VERIFIED: eaa47f7 -->
+<!-- LAST_VERIFIED: c6e47b9 -->
 
 These guides explain PipelineHealer by capability so beginners and experienced operators can quickly find what they need.
 


### PR DESCRIPTION
## Summary\n- run full markdown audit for release/status drift after v0.3.0\n- fix remaining portability wording drift in Kubernetes/runbook planning references\n- normalize LAST_VERIFIED markers across all audited docs to c6e47b9\n\n## Scope\n- docs only (no runtime/code changes)\n\n## Key fixes\n- README/docs roadmap/baseline consistency kept on v0.3.0 released + v0.3.1 active\n- Kubernetes portability tracker #37 references updated to closed status where applicable