### PR TITLE
docs(k8s): platform-neutral deployment profile naming guidance

### DIFF
--- a/docs/FUTURE_PLAN.md
+++ b/docs/FUTURE_PLAN.md
@@ -1,6 +1,6 @@
 # Future Plan (Versioned Roadmap)
 
-<!-- LAST_VERIFIED: c6e47b9 -->
+<!-- LAST_VERIFIED: 4ec8637 -->
 
 This roadmap is version-driven. Backlog work is planned against target releases, not ad-hoc phases.
 
@@ -414,6 +414,7 @@ These items are researched and tracked; some have scoped phased rollout while ot
 | `BL-039` | Activity Detail `Assign to Agent` integration (`copy_only` + optional `webhook`) with audit-safe handoff controls ([#42](https://github.com/Canepro/pipelinehealer/issues/42)) | `v0.3.1` | minor | Medium | Planned |
 | `BL-040` | Release umbrella tracking for bundled `v0.3.0` scope (`BL-036`, `BL-038`) ([#43](https://github.com/Canepro/pipelinehealer/issues/43)) | `v0.3.0` | patch | High | Completed (released in `v0.3.0`) |
 | `BL-041` | Release umbrella tracking for bundled `v0.3.1` integration scope (`BL-034`, `BL-039`) ([#44](https://github.com/Canepro/pipelinehealer/issues/44)) | `v0.3.1` | patch | High | Tracking (active) |
+| `BL-042` | Platform-neutral Kubernetes deployment profiles + docs guidance (`values.quickstart.yaml`, `values.production.yaml`) with optional installer automation follow-up ([#51](https://github.com/Canepro/pipelinehealer/issues/51)) | `TBD (post-submission, no release cut required)` | patch | High | Planned |
 
 ## Definition of Done (Per Version)
 

--- a/docs/KUBERNETES_HELM_RUNBOOK.md
+++ b/docs/KUBERNETES_HELM_RUNBOOK.md
@@ -1,6 +1,6 @@
 # Kubernetes Helm Runbook
 
-<!-- LAST_VERIFIED: c6e47b9 -->
+<!-- LAST_VERIFIED: 4ec8637 -->
 
 This runbook adds Kubernetes as a secondary deployment target while keeping Azure Container Apps as the default path.
 
@@ -49,6 +49,17 @@ Important for open-source adopters:
 - Chart: `charts/pipelinehealer`
 - Defaults: `charts/pipelinehealer/values.yaml`
 
+## Deployment Profile Naming (Platform-Neutral)
+
+Use profile names that describe intent, not cluster distro/tooling:
+
+- `values.quickstart.yaml`: fast local/lab onboarding profile (non-production)
+- `values.production.yaml`: hardened production profile
+- optional overlays: `values.<env>.yaml` for team/environment-specific deltas
+
+Avoid naming that implies single-platform support (for example `values.kind.*.yaml`).
+PipelineHealer supports Kubernetes generally; profile names should communicate posture, not vendor/runtime.
+
 ## Public OCI Chart (Recommended)
 
 When chart artifacts are available in GHCR, install directly from OCI:
@@ -58,7 +69,7 @@ helm upgrade --install pipelinehealer oci://ghcr.io/canepro/charts/pipelineheale
   --version X.Y.Z \
   --namespace pipelinehealer \
   --create-namespace \
-  -f values.prod.yaml
+  -f values.production.yaml
 ```
 
 If you are iterating locally from source, install from `./charts/pipelinehealer` as shown below.
@@ -79,7 +90,7 @@ Important:
 helm upgrade --install pipelinehealer ./charts/pipelinehealer \
   --namespace pipelinehealer \
   --create-namespace \
-  -f values.prod.yaml
+  -f values.production.yaml
 ```
 
 4. Verify rollout:
@@ -223,7 +234,7 @@ helm upgrade --install pipelinehealer ./charts/pipelinehealer \
   --create-namespace \
   --set backend.image.tag=vX.Y.Z \
   --set frontend.image.tag=vX.Y.Z \
-  -f values.prod.yaml
+  -f values.production.yaml
 ```
 
 ## Port-Forward Validation (No Ingress)


### PR DESCRIPTION
## Summary
- add platform-neutral Kubernetes values profile naming guidance (`values.quickstart.yaml`, `values.production.yaml`)
- remove `values.prod.yaml` references in Helm runbook examples
- add roadmap tracking row for `BL-042` as post-submission work with no release-cut requirement
- sync `LAST_VERIFIED` markers for touched docs

## Tracking
- refs #51

## Scope
- docs-only change
- no runtime/chart behavior changes
