### PR TITLE
docs: align README and runbooks with v0.3.3 behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # PipelineHealer
 
-<!-- LAST_VERIFIED: 310d40e -->
+<!-- LAST_VERIFIED: 41575cf -->
 
 > Policy-aware CI/CD remediation platform for GitHub Actions failures.
 
 [![Live Demo](https://img.shields.io/badge/Live_Demo-Try_It-brightgreen)](https://ca-canepro-ph-frontend.kinddune-53ac219d.eastus2.azurecontainerapps.io)
 [![Azure](https://img.shields.io/badge/Azure-Deployed-blue)](https://azure.microsoft.com)
-[![Release](https://img.shields.io/badge/Release-v0.3.1-blue)](https://github.com/Canepro/pipelinehealer/releases/tag/v0.3.1)
+[![Release](https://img.shields.io/badge/Release-v0.3.3-blue)](https://github.com/Canepro/pipelinehealer/releases/tag/v0.3.3)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
 PipelineHealer ingests failed workflow runs, diagnoses root causes, and applies controlled remediation:
@@ -21,10 +21,10 @@ PipelineHealer ingests failed workflow runs, diagnoses root causes, and applies 
 
 - Public repository: `https://github.com/Canepro/pipelinehealer`
 - Live deployment: Azure Container Apps (backend + frontend)
-- Current release baseline: [`v0.3.1`](https://github.com/Canepro/pipelinehealer/releases/tag/v0.3.1)
-- Next scoped target: `v0.3.2` ([#44](https://github.com/Canepro/pipelinehealer/issues/44))
-- `v0.3.2` freeze-required scope: `#36` (Jenkins bridge), `#42` (Assign-to-Agent), `#57` (storage posture hardening)
-- OSS-friendly durable storage path: PostgreSQL adapter (`#58`) is now available as an alternative durable backend
+- Current release baseline: [`v0.3.3`](https://github.com/Canepro/pipelinehealer/releases/tag/v0.3.3)
+- `v0.3.2` required freeze scope shipped: `#36` (Jenkins bridge), `#42` (Assign-to-Agent), `#57` (storage posture hardening)
+- OSS-friendly durable storage is available: PostgreSQL adapter (`#58`) alongside Cosmos DB and in-memory development mode
+- Current release tracking umbrella: [#44](https://github.com/Canepro/pipelinehealer/issues/44)
 - Demo runbook: [docs/DEMO_SCRIPT.md](docs/DEMO_SCRIPT.md)
 
 ## Example Remediation Stories
@@ -145,45 +145,33 @@ CI failures create repetitive triage work and slow delivery. PipelineHealer redu
 - Operational traceability: every action links to run evidence, reason codes, and policy state.
 - Deployment flexibility: same control model across Azure, Kubernetes, and local container paths.
 
-## v0.3.2 Freeze Guardrails (Applied)
+## Recent Releases
 
-- Required scope is locked to `#36/#42/#57` to protect submission reliability.
-- `#58` (PostgreSQL adapter) was implemented adapter-first after required scope completion.
-- Storage extensibility work must remain adapter-scoped and additive (no core workflow rewrites).
+### v0.3.3
 
-## v0.3.2 Integration Scope (Current)
+- Landing page polish: scroll entrance animations, capability counters, and architecture diagram.
+- Release/deploy alignment: frontend package + chart + backend versions synchronized and deployed to ACA.
 
-- Signed Jenkins bridge ingestion endpoint for Jenkins-primary CI paths: `POST /webhook/jenkins`
-- Jenkins bridge replay protection hardened for concurrent ingress (atomic nonce/delivery reservation path).
-- Assign-to-Agent handoff integration with runtime-safe modes:
-  - `copy_only` (audited, no network delivery)
-  - `webhook` (bounded timeout/retry + destination allowlist)
-- Explicit storage posture guardrails:
+### v0.3.2
+
+- Signed Jenkins bridge ingestion path for Jenkins-primary CI coverage: `POST /webhook/jenkins`.
+- Assign-to-Agent handoff integration (`copy_only` and optional `webhook`) with audited controls.
+- Storage posture hardening:
   - non-development fail-fast when durable storage is required but missing
   - explicit non-development in-memory mode requires opt-in
-- OSS-friendly durable storage path:
-  - `STORAGE_MODE=postgres` with `POSTGRES_DSN`
+- PostgreSQL durable adapter shipped as OSS-friendly persistence path (`STORAGE_MODE=postgres`, `POSTGRES_DSN`).
 
-## What Shipped In v0.3.1
+### v0.3.1
 
-- frontend runtime-first config for containerized deployments (`VITE_*` via `/runtime-config.js`)
-- no-rebuild config updates through runtime env sync paths (ACA/Helm/compose)
-- release workflow/frontend image decoupled from auth build-arg coupling
+- Frontend runtime-first config for containerized deployments (`VITE_*` via `/runtime-config.js`).
+- No-rebuild config updates through runtime env sync paths (ACA/Helm/compose).
+- Release workflow/frontend image decoupled from auth build-arg coupling.
 
-## Previously Shipped In v0.3.0
-
-- Activity Detail `Copy Context` for one-click AI-ready handoff payloads (bounded + redacted)
-- visible disabled `Assign to Agent` affordance (`Coming Soon`) for discoverability
-- release hardening with anonymous GHCR pullability gating for:
-  - backend/frontend tags (`vX.Y.Z` and `X.Y.Z`)
-  - backend/frontend digests
-  - Helm chart OCI tag (`X.Y.Z`)
-
-Release notes: [CHANGELOG.md](CHANGELOG.md), [v0.3.1 release](https://github.com/Canepro/pipelinehealer/releases/tag/v0.3.1), and [v0.3.0 release](https://github.com/Canepro/pipelinehealer/releases/tag/v0.3.0)
+Release notes: [CHANGELOG.md](CHANGELOG.md), [v0.3.3 release](https://github.com/Canepro/pipelinehealer/releases/tag/v0.3.3), [v0.3.2 release](https://github.com/Canepro/pipelinehealer/releases/tag/v0.3.2), and [v0.3.1 release](https://github.com/Canepro/pipelinehealer/releases/tag/v0.3.1)
 
 ## Kubernetes Portability Status
 
-As of March 3, 2026 (`v0.3.1`), random-user image pullability regressions are gated in release automation.
+As of March 5, 2026 (`v0.3.3`), random-user image pullability regressions are gated in release automation.
 
 - previous portability gap issue [#37](https://github.com/Canepro/pipelinehealer/issues/37) is closed
 - Helm success output alone is still not sufficient proof; verify rollout and image pulls on clean clusters

--- a/docs/AGENT_HANDOFF_CONTEXT_MINISPEC.md
+++ b/docs/AGENT_HANDOFF_CONTEXT_MINISPEC.md
@@ -1,12 +1,12 @@
 # Agent Handoff + Copy Context Mini-Spec
 
-<!-- LAST_VERIFIED: 3116334 -->
+<!-- LAST_VERIFIED: 41575cf -->
 
-Status: Phase 0/1 released in `v0.3.0` (`Copy Context` + disabled `Assign to Agent`), Phase 2 pending (`v0.3.2`)
+Status: Phase 0/1 released in `v0.3.0` (`Copy Context` + disabled `Assign to Agent`), Phase 2 delivered in `v0.3.2` (`copy_only`/`webhook`)
 Owner: PipelineHealer maintainers
 Scope target:
 - `v0.3.0`: `Copy Context` + disabled `Assign to Agent` `Coming Soon` affordance
-- `v0.3.2`: functional agent handoff integration (`copy_only`/`webhook`)
+- `v0.3.2`: functional agent handoff integration (`copy_only`/`webhook`) delivered
 
 ## Problem
 

--- a/docs/DEMO_SCRIPT.md
+++ b/docs/DEMO_SCRIPT.md
@@ -1,6 +1,6 @@
 # PipelineHealer Demo Recording Guide (Single-File Runbook)
 
-<!-- LAST_VERIFIED: d0bd771 -->
+<!-- LAST_VERIFIED: 41575cf -->
 
 Use this as the only doc during recording day. It includes:
 
@@ -16,10 +16,25 @@ Related docs:
 - `docs/API.md` for full API endpoint reference and best practices
 - `docs/CLI.md` for the full CLI command reference
 
+## Hackathon Requirement Alignment (March 5, 2026)
+
+This runbook aligns to the submission checklist in `docs/HACKATHON_LOG.md`:
+
+- Public repository: `https://github.com/Canepro/pipelinehealer`
+- Live Azure deployment: `bash scripts/ph.sh urls`
+- Project description: `README.md`
+- Architecture diagram: `README.md` -> `Architecture` section
+- Microsoft Learn profiles:
+  - Vincent Mogah: `https://learn.microsoft.com/en-us/users/canepro0084/`
+  - Logeshwaran R: `https://learn.microsoft.com/en-in/users/logeshwaranr-5820/`
+  - Goziechukwu Chima-Duru: `https://learn.microsoft.com/en-us/users/GozieChimaDuru-2688`
+
+Remaining submission item this doc drives: demo video length must be 2:00 max.
+
 Default values used in this runbook:
 
 ```bash
-export RELEASE_TAG="${RELEASE_TAG:-v0.3.1}"
+export RELEASE_TAG="${RELEASE_TAG:-v0.3.3}"
 export DEMO_REPO="${DEMO_REPO:-Canepro/pipelinehealer-demo}"
 ```
 
@@ -86,6 +101,13 @@ Pass check:
 
 ```bash
 bash scripts/ph.sh demo:e2e --repo "$DEMO_REPO" --triggers dependency,lint,test,build_config,timeout --wait-seconds 180 --ci-signal-wait-seconds 180
+```
+
+This is the recommended on-camera subset for time control.
+If you need full fixture coverage, include `prettier,docker`:
+
+```bash
+bash scripts/ph.sh demo:e2e --repo "$DEMO_REPO" --triggers dependency,lint,test,build_config,timeout,prettier,docker --wait-seconds 180 --ci-signal-wait-seconds 180
 ```
 
 What this command does:
@@ -164,7 +186,7 @@ Enriched activities show an "External Findings Details" collapsible panel in Act
 
 ## 5) 2-Minute Recording Script (Final)
 
-Timing sanity check (March 3, 2026):
+Timing sanity check (March 5, 2026):
 - core `TELL` script (excluding optional insert) is ~127 words
 - at ~110-130 WPM, spoken narration is ~59-69 seconds
 - keep transitions/clicks concise; treat the optional differentiator as a swap-in, not an add-on, to stay under 2:00

--- a/docs/FUTURE_PLAN.md
+++ b/docs/FUTURE_PLAN.md
@@ -1,6 +1,6 @@
 # Future Plan (Versioned Roadmap)
 
-<!-- LAST_VERIFIED: 310d40e -->
+<!-- LAST_VERIFIED: 41575cf -->
 
 This roadmap is version-driven. Backlog work is planned against target releases, not ad-hoc phases.
 
@@ -38,6 +38,8 @@ This roadmap is version-driven. Backlog work is planned against target releases,
 | `v0.2.11` | Released | Runtime control-surface separation + canary policy hardening + Kubernetes pullability docs clarity |
 | `v0.3.0` | Released | Activity Detail AI handoff UX baseline (`Copy Context` + disabled `Assign to Agent`) + anonymous GHCR pullability gate hardening |
 | `v0.3.1` | Released | Frontend runtime-config decoupling for containerized `VITE_*` settings + deploy/workflow/docs alignment |
+| `v0.3.2` | Released | Jenkins bridge + Assign-to-Agent activation + storage posture hardening + PostgreSQL adapter |
+| `v0.3.3` | Released | Landing-page polish + release/deploy alignment to ACA and Helm `0.3.3` |
 
 ## Released Target: `v0.2.6` (Verification Learning + Diagnostics Signal Clarity)
 
@@ -219,77 +221,39 @@ Theme: operator handoff UX baseline + Kubernetes portability release hardening.
 4. No regressions in existing Activity Detail actions (`Retry`, `Backfill Diagnostics`).
 5. Release docs and changelog match shipped behavior.
 
-## Active Target: `v0.3.2` (Minor)
+## Released Target: `v0.3.2` (Minor)
 
 Theme: integration activation for non-GitHub CI ingestion and agent handoff.
 
-### Must-Have Scope
+### Delivered Scope
 
 1. Jenkins bridge ingestion (`BL-034`)
-   - Add signed ingestion path for external CI failures (Jenkins) into PipelineHealer activity pipeline.
-   - Normalize payload shape (`repo`, `sha`, `branch`, `job_url`, `failed_stage`, compact logs, timestamp).
+   - Added signed ingestion path for external CI failures (Jenkins) into PipelineHealer activity pipeline.
+   - Normalized payload shape (`repo`, `sha`, `branch`, `job_url`, `failed_stage`, compact logs, timestamp).
 2. `Assign to Agent` functional handoff (`BL-039`)
-   - Activate the `Coming Soon` control with configured handoff modes (`copy_only`/`webhook`).
-   - Keep disabled-by-default runtime behavior and auditable request correlation.
+   - Activated configurable handoff modes (`copy_only`/`webhook`) with audited controls.
 3. Storage posture hardening (`BL-045`)
-   - Enforce explicit storage mode contract and non-development durability guardrails.
-   - Fail fast in non-development when durable storage is required but not configured.
-   - Preserve explicit local/demo in-memory opt-in with operator-visible active backend surface.
-4. Governance and operator verification
-   - Require allowlist, signing, and replay guardrails for bridge/handoff paths.
-   - Add CLI/runbook checks for integration health and failure diagnostics.
-
-### Extended Scope (Implemented After Must-Have Scope)
-
-1. OSS-friendly PostgreSQL durable adapter (`BL-046`)
+   - Enforced explicit storage mode contract and non-development durability guardrails.
+   - Added fail-fast behavior in non-development when durable storage is required but missing.
+4. OSS-friendly PostgreSQL durable adapter (`BL-046`)
    - Added `PostgresStorage` as an adapter-only implementation path.
    - Kept orchestration/core workflow logic backend-agnostic.
-   - Added parity and selection tests plus bootstrap SQL + docs updates.
-   - Implementation tracked in PR `#61`; issue `#58` closes on merge.
 
-### Exit Criteria
+## Released Target: `v0.3.3` (Patch)
 
-1. Jenkins payloads can create auditable activities without GitHub `workflow_run`.
-2. Assign-to-Agent handoff is functional when configured and safe when not configured.
-3. Non-development deploys cannot run accidentally on ephemeral in-memory storage.
-4. Integration failures are non-blocking for core activity workflows.
-5. API/docs/runbooks are aligned with shipped integration behavior.
+Theme: release-quality polish and presentation alignment.
 
-## Planned Target: `v0.3.3` (Minor)
+### Delivered Scope
 
-Theme: complete learning-system operator workflow from candidate signal to safe activation, including lower-friction verification capture.
+1. Landing-page UX polish
+   - Added subtle entrance animations, capability counters, and architecture diagram.
+2. Release/deploy alignment
+   - Published `v0.3.3` backend/frontend images and Helm chart (`0.3.3`) with pullability verification.
+   - Deployed `v0.3.3` to Azure Container Apps.
+3. Docs cleanup
+   - Updated user-facing docs to remove stale `v0.3.1`/`v0.3.2` "current target" language.
 
-### Planned Scope
-
-1. Learning retrieval context in runtime path
-   - Retrieve active learning candidates before diagnosis/remediation.
-   - Add bounded retrieval timeout and safe fallback to normal path.
-2. Candidate editing workflow
-   - Add API + UI to edit candidate fields safely.
-   - Preserve audit trail (`actor`, `request_id`, changed fields, timestamp).
-3. Learning simulation/preview
-   - Add "simulate before activate" operator flow in Control Center.
-   - Show predicted policy impact and safety gates before activation.
-4. Verification capture bridge (GitHub issue comment -> feedback payload)
-   - Define a safe parser for structured "PipelineHealer Accuracy Assessment" comment blocks.
-   - Add explicit API/CLI path to ingest parsed outcomes as `learning/feedback` with traceability metadata.
-   - Keep manual feedback path as fallback when comments are missing or malformed.
-5. Documentation and runbook sync
-   - Update feature docs and operator runbooks for new learning workflow.
-
-### Exit Criteria
-
-1. Contract tests for retrieval + fallback path pass.
-2. Audit coverage for learning edits/actions is visible in UI and API.
-3. Control Center can run simulation without changing live policy.
-4. Structured issue-comment verification can be ingested with clear success/fallback behavior.
-5. Docs updated:
-   - `README.md` (concise user-facing summary)
-   - `docs/API.md`
-   - `docs/LOCAL_DEMO_RUNBOOK.md`
-   - `docs/features/04-learning-system.md`
-
-## Planned Target: `v0.4.0` (Minor)
+## Active Target: `v0.4.0` (Minor)
 
 Theme: MCP operational maturity + observability depth.
 
@@ -368,11 +332,11 @@ These items are researched and tracked; some have scoped phased rollout while ot
 
 ### DP-003: Jenkins Bridge Strategy for GitHub-Adjacent Repos
 
-- Status: `Planned` (recommended to start in `v0.3.2`)
+- Status: `Delivered bridge path` (`v0.3.2`); native provider follow-on remains queued
 - Problem statement:
   - Some onboarded repos are Jenkins-primary and may not emit GitHub `workflow_run` failures, so PipelineHealer receives no trigger despite webhook allowlisting.
-- Recommended option:
-  - Build a signed Jenkins bridge ingestion path into PipelineHealer first (`v0.3.2`) before full native Jenkins adapter work.
+- Delivered option:
+  - Built a signed Jenkins bridge ingestion path into PipelineHealer first (`v0.3.2`) before full native Jenkins adapter work.
 - Why this option:
   - Reuses existing diagnosis/remediation pipeline quickly.
   - Preserves current policy/audit model.
@@ -388,9 +352,9 @@ These items are researched and tracked; some have scoped phased rollout while ot
 
 | ID | Item | Recommended Target | Type | Priority | Status |
 |---|---|---|---|---|---|
-| `BL-001` | Learning retrieval-before-diagnosis/remediation | `v0.3.3` | minor | High | Planned |
-| `BL-002` | Learning candidate edit API/UI + audit metadata | `v0.3.3` | minor | High | Planned |
-| `BL-003` | Learning simulation/preview controls in Control Center | `v0.3.3` | minor | High | Planned |
+| `BL-001` | Learning retrieval-before-diagnosis/remediation | `v0.4.0` | minor | High | Planned |
+| `BL-002` | Learning candidate edit API/UI + audit metadata | `v0.4.0` | minor | High | Planned |
+| `BL-003` | Learning simulation/preview controls in Control Center | `v0.4.0` | minor | High | Planned |
 | `BL-004` | MCP policy visualization + approval UX completion | `v0.4.0` | minor | Medium | Planned |
 | `BL-005` | Token/cost telemetry and degradation alerts | `v0.4.0` | minor | Medium | Planned |
 | `BL-006` | In-app investigation/log viewer (bounded) | `v0.4.x` | patch/minor | Medium | Queued |
@@ -412,14 +376,14 @@ These items are researched and tracked; some have scoped phased rollout while ot
 | `BL-022` | Demo verification output clarity (`mcp_tool_calls_total` vs passive-only counters) | `v0.2.7` | patch | High | Completed (in `main`) |
 | `BL-023` | Docs/runbook MCP interpretation hardening for non-expert operators | `v0.2.7` | patch | High | Completed (in `main`) |
 | `BL-024` | Release baseline alignment (`v0.2.7`) across README/CLI/runbooks | `v0.2.7` | patch | Medium | Completed (in `main`) |
-| `BL-025` | Accuracy-assessment bridge: ingest structured GitHub issue verification comments into `learning/feedback` with audit traceability | `v0.3.3` | minor | High | Planned |
+| `BL-025` | Accuracy-assessment bridge: ingest structured GitHub issue verification comments into `learning/feedback` with audit traceability | `v0.4.0` | minor | High | Planned |
 | `BL-026` | Cross-platform operator support: PowerShell wrapper + non-Azure deploy wrapper strategy for `ph` commands | `v0.5.0` | minor | Medium | Planned |
 | `BL-027` | AKS/Helm onboarding hardening: explicit required-vs-optional auth paths, Entra build-time vs runtime guardrails, and post-deploy auth verification checklist ([#32](https://github.com/Canepro/pipelinehealer/issues/32)) | `v0.3.0` | patch | Medium | Completed (in `main`) |
 | `BL-028` | Submission-baseline drift control (`v0.2.8`): release auth build-var gating + docs version alignment pass | `v0.2.8` | patch | High | Completed (in `main`) |
 | `BL-029` | Azure deploy hardening option: `--secure-secrets` path in deploy tooling (`ph.sh` + redeploy script) with operator docs for secretref-backed runtime env | `v0.2.9` | patch | High | Completed (released in `v0.2.9`) |
 | `BL-030` | GH-AW + GitHub MCP hybrid diagnostics ingestion mode (`GH_AW_INGESTION_MODE=hybrid`) across backend/UI/CLI/docs | `v0.2.9` | patch | High | Completed (released in `v0.2.9`) |
 | `BL-031` | Passive backfill label-mismatch reliability fix (unlabeled fallback matching for ci-doctor findings) ([#35](https://github.com/Canepro/pipelinehealer/issues/35)) | `v0.2.9` | patch | High | Completed (released in `v0.2.9`) |
-| `BL-032` | Copilot integration research track: evaluate coding-agent + MCP coexistence model without bypassing PipelineHealer governance | `v0.3.2` | minor | Medium | Planned (phased via `BL-038`/`BL-039`) |
+| `BL-032` | Copilot integration research track: evaluate coding-agent + MCP coexistence model without bypassing PipelineHealer governance | `v0.4.x` | minor | Medium | Planned (phased via `BL-038`/`BL-039`) |
 | `BL-033` | Multi-platform notifications research track: Slack/Teams/Rocket.Chat delivery model for non-admin stakeholders with auditable outbound events | `TBD (post-submission)` | minor | Medium | Research / Undecided |
 | `BL-034` | Jenkins bridge ingestion path: signed external CI failure payload -> synthetic PipelineHealer activity (`source_selection_path=jenkins_bridge`) with issue-first defaults ([#36](https://github.com/Canepro/pipelinehealer/issues/36)) | `v0.3.2` | minor | High | Completed (merged to `main`) |
 | `BL-035` | Native Jenkins provider adapter: deeper job metadata/log/artifact retrieval + rerun/governance parity with existing provider model | `v0.5.x` | minor | Medium | Queued |
@@ -433,7 +397,7 @@ These items are researched and tracked; some have scoped phased rollout while ot
 | `BL-043` | Frontend runtime-config decoupling: make containerized `VITE_*` settings runtime-first across frontend/Helm/Azure deploy tooling and remove build-arg coupling in release path ([#54](https://github.com/Canepro/pipelinehealer/issues/54)) | `v0.3.1` | patch | High | Completed (released in `v0.3.1`) |
 | `BL-044` | Azure env-sync regression fix: keep existing frontend runtime config when `VITE_*` keys are omitted from env input during `deploy:env` ([#55](https://github.com/Canepro/pipelinehealer/issues/55)) | `v0.3.2` | patch | High | Completed (merged to `main`) |
 | `BL-045` | Storage posture hardening: explicit storage mode + non-development durability guardrail with fail-fast misconfiguration behavior ([#57](https://github.com/Canepro/pipelinehealer/issues/57)) | `v0.3.2` | patch | High | Completed (merged to `main`) |
-| `BL-046` | PostgreSQL durable storage adapter (OSS-friendly persistence path) with adapter-contract parity requirements ([#58](https://github.com/Canepro/pipelinehealer/issues/58)) | `v0.3.2` | minor | Medium | Implemented in PR `#61` (pending merge / issue closure) |
+| `BL-046` | PostgreSQL durable storage adapter (OSS-friendly persistence path) with adapter-contract parity requirements ([#58](https://github.com/Canepro/pipelinehealer/issues/58)) | `v0.3.2` | minor | Medium | Completed (released in `v0.3.2`) |
 
 ## Definition of Done (Per Version)
 

--- a/docs/HACKATHON_LOG.md
+++ b/docs/HACKATHON_LOG.md
@@ -29,12 +29,12 @@ This is the long-form project tracker for hackathon execution status, submission
 - Canary scope expanded (issue-only safe mode) to `canepro/portfolio_website-main`, `canepro/rocketchat-k8s`, and `canepro/central-observability-hub-stack`; Jenkins-primary repo coverage gap identified and now tracked as bridge-first plan (`DP-003`, `BL-034`, target `v0.3.2`)
 - Release planning split is active:
   - `v0.3.0` scope tracking issue: [#43](https://github.com/Canepro/pipelinehealer/issues/43) (`BL-036` + `BL-038`)
-- `v0.3.2` scope tracking issue: [#44](https://github.com/Canepro/pipelinehealer/issues/44) (required: `BL-034` + `BL-039` + `BL-045`; `BL-046` implemented in PR [#61](https://github.com/Canepro/pipelinehealer/pull/61), pending merge/issue closure)
+- `v0.3.2` scope tracking issue: [#44](https://github.com/Canepro/pipelinehealer/issues/44) (required: `BL-034` + `BL-039` + `BL-045`; `BL-046` shipped in `v0.3.2` via PR [#61](https://github.com/Canepro/pipelinehealer/pull/61))
 - `v0.3.2` freeze guardrails are now explicit:
   - required scope locked to `#36/#42/#57` for submission reliability
   - `#58` (PostgreSQL adapter) was implemented only after required scope was complete, CI green, and docs synced
   - storage extensibility remained adapter-scoped (no core workflow rewrites during freeze)
-- Release `v0.3.1` is the current public baseline; `v0.3.2` is now the active integration target
+- Release `v0.3.3` is the current public baseline; forward planning target is `v0.4.0`
 - `v0.3.1` runtime-config decoupling shipped:
   - release published: `https://github.com/Canepro/pipelinehealer/releases/tag/v0.3.1`
   - runtime-first frontend config tracked in [#54](https://github.com/Canepro/pipelinehealer/issues/54)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Docs Index
 
-<!-- LAST_VERIFIED: 310d40e -->
+<!-- LAST_VERIFIED: 41575cf -->
 
 Use this index to find the right doc quickly.
 
@@ -28,7 +28,7 @@ Use this index to find the right doc quickly.
 ### Tier 3 — Internal/Transient (author discretion; archive post-submission)
 
 - `HACKATHON_LOG.md` — current phase status, submission checklist, milestone history, and freeze tracking notes
-- `FUTURE_PLAN.md` — version-targeted roadmap (active `v0.3.2` scope includes `BL-034/BL-039/BL-045`, with `BL-046` implementation tracked via PR/issue status)
+- `FUTURE_PLAN.md` — version-targeted roadmap (released through `v0.3.3`; current forward planning starts at `v0.4.0`)
 - `UI_PLAN.md` — UI maturity plan, principles, and weekly tracking through submission
 - `AGENT_HANDOFF_CONTEXT_MINISPEC.md` — draft design for Activity Detail `Copy Context` + optional `Assign to Agent` handoff integration
 - `GH_AW_IMPLEMENTATION_TRACKER.md` — gh-aw research summary, Layer 1/2 checklists, decision log, and evidence


### PR DESCRIPTION
## Summary
- align README release/baseline language with v0.3.3
- refresh demo script defaults and hackathon requirement mapping
- update roadmap/docs index and handoff minispec status wording
- sync LAST_VERIFIED markers for edited user-facing docs

## Validation
- doc consistency grep for stale v0.3.1/v0.3.2 current-target wording
- CLI command references checked against scripts/ph.sh help