### PR TITLE
Fix workflow shutdown task-map mutation race

### DIFF
--- a/backend/src/workflows/pipeline_healer.py
+++ b/backend/src/workflows/pipeline_healer.py
@@ -76,11 +76,14 @@ class PipelineHealerWorkflow:
     async def close(self) -> None:
         """Clean up resources."""
         # Cancel any running tasks
-        for _task_id, task in self._running_tasks.items():
+        # Iterate over a snapshot because task done-callbacks mutate
+        # ``self._running_tasks`` by popping completed task IDs.
+        for task_id, task in list(self._running_tasks.items()):
             if not task.done():
                 task.cancel()
                 with suppress(asyncio.CancelledError):
                     await task
+            self._running_tasks.pop(task_id, None)
 
         await self._github_tools.close()
         await self._storage.close()

--- a/backend/tests/test_backfill_diagnostics.py
+++ b/backend/tests/test_backfill_diagnostics.py
@@ -1,5 +1,7 @@
 """Tests for external diagnostics backfill sweep."""
 
+import asyncio
+
 import pytest
 
 from src.agents.orchestrator import OrchestratorAgent
@@ -303,3 +305,25 @@ async def test_workflow_sweep_returns_zero_when_no_candidates():
     )
     count = await workflow.run_backfill_sweep()
     assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_workflow_close_handles_running_task_callback_mutation():
+    """workflow.close should not fail when done-callback mutates running task map."""
+    storage = InMemoryStorage()
+    gt = _DummyGitHubTools()
+    workflow = PipelineHealerWorkflow(
+        github_tools=gt,
+        storage=storage,
+        azure_credential=None,
+    )
+
+    async def _never_finishes() -> None:
+        await asyncio.sleep(300)
+
+    task = asyncio.create_task(_never_finishes())
+    workflow._running_tasks["task-1"] = task
+    task.add_done_callback(lambda _: workflow._running_tasks.pop("task-1", None))
+
+    await workflow.close()
+    assert workflow._running_tasks == {}


### PR DESCRIPTION
## Summary
- fix `PipelineHealerWorkflow.close()` to avoid mutating `_running_tasks` during dict iteration
- iterate over a snapshot and safely pop entries after cancel/await
- add regression coverage for done-callback mutation during shutdown

## Root Cause
`close()` iterated `self._running_tasks.items()` while awaiting cancelled tasks. Task done-callbacks pop from `_running_tasks`, which mutated the dict during iteration and raised `RuntimeError: dictionary changed size during iteration`.

## Validation
- `pytest -q backend/tests/test_backfill_diagnostics.py` (9 passed)
- `pytest -q` in `backend/` (251 passed)
- local smoke rerun confirmed clean shutdown (no `Application shutdown failed` / dict-size RuntimeError)
- `bash scripts/release_verify.sh v0.3.3` passed
