### PR TITLE
Add handoff receiver smoke-test guidance

### DIFF
--- a/docs/LOCAL_DEMO_RUNBOOK.md
+++ b/docs/LOCAL_DEMO_RUNBOOK.md
@@ -179,7 +179,8 @@ AGENT_HANDOFF_WEBHOOK_ALLOWLIST=
 Settings UI note:
 - The Settings page now includes a webhook setup assistant for Assign-to-Agent.
 - It validates a candidate webhook URL, derives the destination host, and generates a portable env block you can copy into local `.env`, Docker/Helm values, or cloud deployment adapters.
-- It also generates a sample receiver payload and a `curl` smoke test so you can validate the webhook target before changing deployment config.
+- It also generates a sample webhook event payload and a `curl` smoke test that use the same JSON schema as the real Assign-to-Agent webhook (including `activity.repository`, `activity.workflow_run_id`, and `activity.failure_type`) so you can validate the webhook target before changing deployment config.
+- The sample payload intentionally omits deployment-only values and should be treated as the canonical expected JSON shape for receiver validation.
 - The actual webhook URL remains startup configuration; it is not returned by the API.
 
 > **That's it for getting started.** Everything else in `.env` has sensible defaults. You can tune optional settings later — see the full list in `backend/.env.example`.

--- a/frontend/src/components/settings/AdminControlsForm.tsx
+++ b/frontend/src/components/settings/AdminControlsForm.tsx
@@ -134,22 +134,23 @@ function parseWebhookUrlInput(value: string): { url: string; host: string } | nu
   }
 }
 
-function buildHandoffSamplePayload(candidateUrl: string) {
+function buildHandoffSamplePayload() {
   return JSON.stringify(
     {
       delivery_id: 'handoff:test-delivery',
       request_id: 'ph-settings-smoke-test',
       activity: {
         id: 'activity-demo-123',
-        repository_name: 'canepro/pipelinehealer-demo',
+        repository: 'canepro/pipelinehealer-demo',
         workflow_name: 'CI',
+        workflow_run_id: 1234567890,
         status: 'failed',
+        failure_type: null,
       },
       context_format: 'markdown',
       context:
         '## PipelineHealer handoff smoke test\n\nThis is a generated sample payload for validating the receiver contract.',
       sent_at: '2026-03-05T22:30:00Z',
-      target_url: candidateUrl,
     },
     null,
     2
@@ -305,9 +306,7 @@ export default function AdminControlsForm({
         `AGENT_HANDOFF_MAX_RETRIES=${form.agent_handoff_max_retries}`,
       ].join('\n')
     : ''
-  const handoffSamplePayload = handoffWebhookDraft
-    ? buildHandoffSamplePayload(handoffWebhookDraft.url)
-    : ''
+  const handoffSamplePayload = handoffWebhookDraft ? buildHandoffSamplePayload() : ''
   const handoffSmokeCurl = handoffWebhookDraft
     ? [
         'curl -X POST \\',


### PR DESCRIPTION
## Summary
- extend the handoff webhook setup assistant with a sample receiver payload
- generate a copyable curl smoke test for validating the receiver endpoint
- document the new smoke-test helper in the local demo runbook

## Validation
- bun run lint
- bun run build

## Notes
- replacement for closed PR #72 after its stacked base merged