### PR TITLE
Improve notification readability and surface deployed version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-<!-- LAST_VERIFIED: 85a9cbd -->
+<!-- LAST_VERIFIED: fa18d60 -->
 
 All notable changes to this project will be documented in this file.
 
@@ -8,7 +8,7 @@ The format is based on Keep a Changelog and this repo uses Semantic Versioning.
 
 ## [Unreleased]
 
-- Release-lineage reference for `v0.5.1` scope continuity: `01c1018`.
+- Release-lineage reference for `v0.5.2` scope continuity: `fa18d60`.
 
 ## [v0.5.1] - 2026-03-06
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # PipelineHealer
 
-<!-- LAST_VERIFIED: fadd4cf -->
+<!-- LAST_VERIFIED: fa18d60 -->
 
 > OSS-first, policy-aware pipeline remediation platform with GitHub Actions and Jenkins bridge support today.
 
 [![Live Demo](https://img.shields.io/badge/Live_Demo-Try_It-brightgreen)](https://ca-canepro-ph-frontend.kinddune-53ac219d.eastus2.azurecontainerapps.io)
 [![Azure](https://img.shields.io/badge/Azure-Deployed-blue)](https://azure.microsoft.com)
-[![Release](https://img.shields.io/badge/Release-v0.4.0-blue)](https://github.com/Canepro/pipelinehealer/releases/tag/v0.4.0)
+[![Release](https://img.shields.io/badge/Release-v0.5.1-blue)](https://github.com/Canepro/pipelinehealer/releases/tag/v0.5.1)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
 PipelineHealer ingests failed pipeline executions, diagnoses root causes, and applies controlled remediation:
@@ -23,8 +23,8 @@ Current provider coverage is GitHub Actions plus a signed Jenkins bridge path. T
 
 - Public repository: `https://github.com/Canepro/pipelinehealer`
 - Live reference deployment: Azure Container Apps (backend + frontend)
-- Current release baseline: [`v0.4.0`](https://github.com/Canepro/pipelinehealer/releases/tag/v0.4.0)
-- Current development umbrella: [#83](https://github.com/Canepro/pipelinehealer/issues/83) (`v0.5.0` outbound integration gateway)
+- Current release baseline: [`v0.5.1`](https://github.com/Canepro/pipelinehealer/releases/tag/v0.5.1)
+- Current forward track: patch hardening after the outbound integration gateway release line
 - `v0.3.2` required freeze scope shipped: `#36` (Jenkins bridge), `#42` (Assign-to-Agent), `#57` (storage posture hardening)
 - OSS-friendly durable storage is available: PostgreSQL adapter (`#58`) alongside Cosmos DB and in-memory development mode
 - Demo runbook: [docs/DEMO_SCRIPT.md](docs/DEMO_SCRIPT.md)
@@ -71,7 +71,7 @@ bun run dev
 ```
 
 5. Verify:
-- `curl -sS http://127.0.0.1:8000/health` returns `{\"status\":\"healthy\"}`
+- `curl -sS http://127.0.0.1:8000/health` returns a healthy response that includes `service`, `version`, and `storage_backend`
 - open `http://127.0.0.1:5173`
 
 Defaults are already beginner-safe in `.env.example`:
@@ -160,8 +160,20 @@ Pipeline failures create repetitive triage work and slow delivery. PipelineHeale
 - Operational traceability: every action links to run evidence, reason codes, and policy state.
 - Deployment flexibility: same control model across Azure, Kubernetes, and local container paths.
 - Platform extensibility: provider-specific adapters can expand beyond GitHub-centric CI into broader delivery and operations pipelines.
+- Operator clarity: the app shell can surface the running UI/API release version so deployed state is visible without external tooling.
 
 ## Recent Releases
+
+### v0.5.1
+
+- Frontend coherence patch: explicit public/app `NotFound` routing and final semantic badge-theme cleanup after live `v0.5.0` validation.
+
+### v0.5.0
+
+- Outbound integration gateway release:
+  - Assign-to-Agent receiver boundary deployed as a low-cost Azure Function reference path
+  - notification sinks shipped for webhook, Slack, Teams, Rocket.Chat, and SMTP-backed email
+  - operator-facing integration health and setup guidance added to Settings and Control Center
 
 ### v0.4.0
 
@@ -192,11 +204,11 @@ Pipeline failures create repetitive triage work and slow delivery. PipelineHeale
 - No-rebuild config updates through runtime env sync paths (ACA/Helm/compose).
 - Release workflow/frontend image decoupled from auth build-arg coupling.
 
-Release notes: [CHANGELOG.md](CHANGELOG.md), [v0.4.0 release](https://github.com/Canepro/pipelinehealer/releases/tag/v0.4.0), [v0.3.3 release](https://github.com/Canepro/pipelinehealer/releases/tag/v0.3.3), and [v0.3.2 release](https://github.com/Canepro/pipelinehealer/releases/tag/v0.3.2)
+Release notes: [CHANGELOG.md](CHANGELOG.md), [v0.5.1 release](https://github.com/Canepro/pipelinehealer/releases/tag/v0.5.1), [v0.5.0 release](https://github.com/Canepro/pipelinehealer/releases/tag/v0.5.0), and [v0.4.0 release](https://github.com/Canepro/pipelinehealer/releases/tag/v0.4.0)
 
 ## Kubernetes Portability Status
 
-As of March 6, 2026 (`v0.4.0`), random-user image pullability regressions are gated in release automation.
+As of March 6, 2026 (`v0.5.1`), random-user image pullability regressions are gated in release automation.
 
 - previous portability gap issue [#37](https://github.com/Canepro/pipelinehealer/issues/37) is closed
 - Helm success output alone is still not sufficient proof; verify rollout and image pulls on clean clusters

--- a/backend/src/__init__.py
+++ b/backend/src/__init__.py
@@ -1,3 +1,13 @@
-"""PipelineHealer - Self-healing CI/CD Agent System."""
+"""PipelineHealer package metadata."""
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+
+def _resolve_version() -> str:
+    try:
+        return version("pipelinehealer")
+    except PackageNotFoundError:
+        return "0.0.0"
+
+
+__version__ = _resolve_version()

--- a/backend/src/api/dashboard.py
+++ b/backend/src/api/dashboard.py
@@ -1215,6 +1215,29 @@ def _handoff_context_preview(context: str, max_chars: int = 280) -> str:
     return sanitized[: max_chars - 3] + "..."
 
 
+def _handoff_activity_url(request: Request, activity_id: str) -> str | None:
+    origin = str(request.headers.get("origin", "") or "").strip().rstrip("/")
+    if not origin.startswith(("http://", "https://")):
+        return None
+    return f"{origin}/app/activities/{activity_id}"
+
+
+def _handoff_summary(activity: ActivityRecord, request: Request) -> dict[str, Any]:
+    diagnosis = activity.diagnosis
+    remediation = activity.remediation_result
+    return {
+        "activity_url": _handoff_activity_url(request, activity.id),
+        "root_cause": (diagnosis.root_cause if diagnosis else "").strip(),
+        "suggested_fix": (diagnosis.suggested_fix if diagnosis else "").strip(),
+        "diagnosis_confidence": float(diagnosis.confidence) if diagnosis else None,
+        "remediation_action": remediation.action_taken.value if remediation else "",
+        "remediation_success": remediation.success if remediation else None,
+        "issue_url": (remediation.issue_url if remediation else "") or "",
+        "pr_url": (remediation.pr_url if remediation else "") or "",
+        "error_message": (remediation.error_message if remediation else "") or "",
+    }
+
+
 def _handoff_actor(request: Request) -> str | None:
     principal = get_request_principal(request)
     if principal is not None:
@@ -2430,6 +2453,7 @@ async def assign_activity_to_agent(
             "status": activity.status.value,
             "failure_type": activity.failure_type.value if activity.failure_type else None,
         },
+        "summary": _handoff_summary(activity, request),
         "context_format": payload.context_format,
         "context": sanitized_context,
         "sent_at": utcnow().isoformat(),

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -12,6 +12,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from .api import dashboard, webhook
+from . import __version__
 from .config import get_settings
 from .observability import configure_observability
 from .workflows.pipeline_healer import PipelineHealerWorkflow, create_workflow
@@ -172,7 +173,7 @@ def create_app() -> FastAPI:
     app = FastAPI(
         title="PipelineHealer",
         description="Self-healing CI/CD agent system",
-        version="0.1.0",
+        version=__version__,
         lifespan=lifespan,
         docs_url="/docs" if settings.environment != "production" else None,
         redoc_url="/redoc" if settings.environment != "production" else None,
@@ -201,7 +202,7 @@ def create_app() -> FastAPI:
         """Root endpoint."""
         return {
             "service": "PipelineHealer",
-            "version": "0.1.0",
+            "version": __version__,
             "status": "running",
         }
 
@@ -210,6 +211,8 @@ def create_app() -> FastAPI:
         """Health check endpoint."""
         storage = getattr(app.state, "storage", None)
         return {
+            "service": "PipelineHealer",
+            "version": __version__,
             "status": "healthy",
             "environment": settings.environment,
             "storage_backend": _resolve_storage_backend_name(storage),

--- a/backend/src/observability.py
+++ b/backend/src/observability.py
@@ -3,6 +3,7 @@
 import logging
 from typing import Any
 
+from . import __version__
 from .config import get_settings
 
 logger = logging.getLogger(__name__)
@@ -51,7 +52,7 @@ def _configure_basic_tracing() -> None:
     resource = Resource.create(
         {
             "service.name": "pipelinehealer",
-            "service.version": "0.1.0",
+            "service.version": __version__,
         }
     )
 

--- a/backend/tests/test_agent_handoff.py
+++ b/backend/tests/test_agent_handoff.py
@@ -292,8 +292,10 @@ async def test_webhook_handoff_success_returns_queued(
 ) -> None:
     from src.api import dashboard
 
+    captured_payload: dict[str, object] = {}
+
     async def _fake_deliver(**kwargs):  # type: ignore[no-untyped-def]
-        _ = kwargs
+        captured_payload.update(kwargs["payload"])
         return True, None
 
     monkeypatch.setattr(dashboard, "_deliver_handoff_webhook", _fake_deliver)
@@ -317,6 +319,66 @@ async def test_webhook_handoff_success_returns_queued(
     body = response.json()
     assert body["status"] == "queued"
     assert body["delivery_id"].startswith("handoff:")
+    summary = captured_payload["summary"]
+    assert summary["root_cause"] == ""
+    assert summary["activity_url"] is None
+
+
+@pytest.mark.asyncio
+async def test_webhook_handoff_payload_includes_summary_and_activity_link(
+    monkeypatch: pytest.MonkeyPatch,
+    _storage: InMemoryStorage,
+) -> None:
+    from src.api import dashboard
+    from src.models import Diagnosis, FailureType, RemediationAction, RemediationResult
+
+    captured_payload: dict[str, object] = {}
+
+    async def _fake_deliver(**kwargs):  # type: ignore[no-untyped-def]
+        captured_payload.update(kwargs["payload"])
+        return True, None
+
+    monkeypatch.setattr(dashboard, "_deliver_handoff_webhook", _fake_deliver)
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.setenv("AGENT_HANDOFF_ENABLED", "true")
+    monkeypatch.setenv("AGENT_HANDOFF_MODE", "webhook")
+    monkeypatch.setenv("AGENT_HANDOFF_WEBHOOK_URL", "https://allowed.example/hook")
+    monkeypatch.setenv("AGENT_HANDOFF_WEBHOOK_ALLOWLIST", "allowed.example")
+    reset_settings()
+
+    activity = ActivityRecord(
+        repositoryId="1",
+        repository_name="canepro/pipelinehealer-demo",
+        workflow_run_id=126,
+        workflow_name="CI",
+        status=RemediationStatus.COMPLETED,
+        failure_type=FailureType.DEPENDENCY,
+        diagnosis=Diagnosis(
+            failure_type=FailureType.DEPENDENCY,
+            confidence=0.92,
+            root_cause="left-pad dependency is missing from package.json",
+            suggested_fix="Add left-pad to dependencies and rebuild the lockfile.",
+        ),
+        remediation_result=RemediationResult(
+            success=True,
+            action_taken=RemediationAction.CREATE_ISSUE,
+            issue_url="https://github.com/Canepro/pipelinehealer/issues/999",
+        ),
+    )
+    activity_id = await _storage.create_activity(activity)
+    response = await _post_handoff(
+        activity_id,
+        {"context": "context text"},
+        headers={"Origin": "https://frontend.example"},
+    )
+    assert response.status_code == 200
+
+    summary = captured_payload["summary"]
+    assert summary["activity_url"] == f"https://frontend.example/app/activities/{activity_id}"
+    assert summary["root_cause"] == "left-pad dependency is missing from package.json"
+    assert summary["suggested_fix"] == "Add left-pad to dependencies and rebuild the lockfile."
+    assert summary["remediation_action"] == "create_issue"
+    assert summary["issue_url"] == "https://github.com/Canepro/pipelinehealer/issues/999"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_agent_handoff_receiver.py
+++ b/backend/tests/test_agent_handoff_receiver.py
@@ -134,3 +134,41 @@ def test_deliver_notification_targets_sends_email(
     assert message["From"] == "pipelinehealer@example.com"
     assert "[PH]" in message["Subject"]
     assert "Canepro/pipelinehealer" in message.get_content()
+
+
+def test_rocketchat_payload_prioritizes_operator_context(receiver_shared: Any) -> None:
+    payload = receiver_shared._rocketchat_payload(  # noqa: SLF001 - focused formatter coverage
+        {
+            "event_type": "agent_handoff_requested",
+            "request_id": "req-123",
+            "delivery_id": "delivery-123",
+            "activity": {
+                "id": "activity-123",
+                "repository": "Canepro/pipelinehealer",
+                "workflow_name": "CI",
+                "status": "completed",
+                "failure_type": "dependency",
+            },
+            "summary": {
+                "activity_url": "https://frontend.example/app/activities/activity-123",
+                "root_cause": "The workflow failed because left-pad is missing.",
+                "suggested_fix": "Add left-pad to dependencies.",
+                "remediation_action": "create_issue",
+                "remediation_success": True,
+                "issue_url": "https://github.com/Canepro/pipelinehealer/issues/321",
+            },
+        },
+        receiver_shared.NotificationTarget(
+            index=1,
+            target_type="rocketchat_webhook",
+            name="rocket-chat",
+        ),
+    )
+
+    assert "PipelineHealer handoff requested" in payload["text"]
+    assert "Diagnosis: The workflow failed because left-pad is missing." in payload["text"]
+    assert "Suggested fix: Add left-pad to dependencies." in payload["text"]
+    assert "Remediation: create issue succeeded" in payload["text"]
+    assert "Open activity: https://frontend.example/app/activities/activity-123" in payload["text"]
+    assert "Open issue: https://github.com/Canepro/pipelinehealer/issues/321" in payload["text"]
+    assert "Delivery ID: delivery-123" in payload["attachments"][0]["text"]

--- a/backend/tests/test_phase2_security.py
+++ b/backend/tests/test_phase2_security.py
@@ -8,6 +8,7 @@ import httpx
 import pytest
 from fastapi import HTTPException
 
+from src import __version__
 from src.api import dashboard, security
 from src.api.security import AuthPrincipal
 from src.config import Settings, get_settings, reset_settings
@@ -864,6 +865,8 @@ async def test_health_exposes_environment_and_storage_backend(monkeypatch) -> No
     response = await _get_health()
     assert response.status_code == 200
     body = response.json()
+    assert body["service"] == "PipelineHealer"
+    assert body["version"] == __version__
     assert body["status"] == "healthy"
     assert body["environment"] == "development"
     assert body["storage_backend"] == "in_memory"

--- a/docs/API.md
+++ b/docs/API.md
@@ -86,6 +86,8 @@ Unauthenticated health check.
 
 ```json
 {
+  "service": "PipelineHealer",
+  "version": "0.5.1",
   "status": "healthy",
   "environment": "production",
   "storage_backend": "cosmos_db"

--- a/docs/DEMO_SCRIPT.md
+++ b/docs/DEMO_SCRIPT.md
@@ -1,6 +1,6 @@
 # PipelineHealer Demo Recording Guide (Single-File Runbook)
 
-<!-- LAST_VERIFIED: fadd4cf -->
+<!-- LAST_VERIFIED: fa18d60 -->
 
 Use this as the only doc during recording day. It includes:
 
@@ -36,7 +36,7 @@ Remaining submission item this doc drives: demo video length must be 2:00 max.
 Default values used in this runbook:
 
 ```bash
-export RELEASE_TAG="${RELEASE_TAG:-v0.4.0}"
+export RELEASE_TAG="${RELEASE_TAG:-v0.5.1}"
 export DEMO_REPO="${DEMO_REPO:-Canepro/pipelinehealer-demo}"
 ```
 

--- a/docs/FUTURE_PLAN.md
+++ b/docs/FUTURE_PLAN.md
@@ -1,6 +1,6 @@
 # Future Plan (Versioned Roadmap)
 
-<!-- LAST_VERIFIED: e2aad10 -->
+<!-- LAST_VERIFIED: fa18d60 -->
 
 This roadmap is version-driven. Backlog work is planned against target releases, not ad-hoc phases.
 
@@ -284,24 +284,28 @@ Theme: operator control-plane coherence + MCP operational maturity.
 4. MCP governance screens no longer show contradictory configured/effective states without explaining the precedence rule.
 5. Release docs, changelog scope, and implementation PRs tracked this work explicitly as `v0.4.0`.
 
-## Active Target: `v0.5.1` (Patch)
+## Active Target: `v0.5.2` (Patch)
 
-Theme: frontend coherence cleanup after live `v0.5.0` validation ([#92](https://github.com/Canepro/pipelinehealer/issues/92)).
+Theme: outbound notification readability + deployed-version visibility after live `v0.5.1` validation.
 
 ### Planned Scope
 
-1. Route correctness
-   - Ensure unknown public and authenticated frontend routes resolve to an explicit `NotFound` state rather than silently falling back to the landing page.
-2. Theme-system completion
-   - Close remaining hardcoded badge/theme drift left by the frontend cleanup pass so semantic CSS vars are used consistently where that pass claimed completion.
-3. Release hygiene
-   - Package the UI/UX cleanup as a tracked patch release instead of leaving local-only frontend edits and artifacts on `main`.
+1. Notification message quality
+   - Replace raw chat payload formatting with operator-grade summaries for Rocket.Chat and keep sink formatting aligned across Slack/Teams/email.
+   - Prioritize diagnosis, remediation outcome, and action links over transport metadata.
+2. Deployed-version visibility
+   - Expose trustworthy backend version data from the running service instead of stale hardcoded constants.
+   - Surface release/version alignment in the app shell so operators can see what is deployed without leaving the UI.
+3. Release/docs hygiene
+   - Sync user-facing docs that still describe `v0.4.0` as the current public baseline.
+   - Keep patch scope documented before merge and release.
 
 ### Exit Criteria
 
-1. Unknown routes consistently render `NotFound` in both public and `/app` paths.
-2. Frontend lint/build remain green after the cleanup.
-3. The patch scope is documented in `CHANGELOG.md` and release planning docs before merge.
+1. Chat/email sink messages summarize handoff context clearly enough for an operator to act without parsing raw JSON.
+2. The running backend reports the correct released version through public health/runtime data.
+3. The UI shows deployed release information clearly and flags frontend/backend drift when present.
+4. Docs and changelog reflect the new patch scope before merge.
 
 ## Released Target: `v0.5.0` (Minor)
 

--- a/docs/HACKATHON_LOG.md
+++ b/docs/HACKATHON_LOG.md
@@ -34,12 +34,11 @@ This is the long-form project tracker for hackathon execution status, submission
   - required scope locked to `#36/#42/#57` for submission reliability
   - `#58` (PostgreSQL adapter) was implemented only after required scope was complete, CI green, and docs synced
   - storage extensibility remained adapter-scoped (no core workflow rewrites during freeze)
-- Release `v0.5.0` is the current public baseline.
-- Post-`v0.5.0` patch target is now `v0.5.1`:
-  - frontend route correctness for explicit 404 behavior outside `/app`
-  - final semantic-theme cleanup for remaining failure badges
-  - release hygiene packaging so UI cleanup lands as tracked patch work, not local drift
-  - release tracker: [#92](https://github.com/Canepro/pipelinehealer/issues/92)
+- Release `v0.5.1` is the current public baseline.
+- Post-`v0.5.1` patch target is now `v0.5.2`:
+  - outbound notification readability for Rocket.Chat/Slack/Teams/email
+  - trustworthy deployed-version visibility in the app shell
+  - cleanup of remaining stale public-version copy after the `v0.5.1` cut
 - Historical `v0.5.0` planning target is now shipped:
   - deployment-facing Assign-to-Agent receiver boundary
   - generic outbound event and notification routing

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Docs Index
 
-<!-- LAST_VERIFIED: 745988e -->
+<!-- LAST_VERIFIED: fa18d60 -->
 
 Use this index to find the right doc quickly.
 
@@ -29,7 +29,7 @@ Use this index to find the right doc quickly.
 ### Tier 3 — Internal/Transient (author discretion; archive post-submission)
 
 - `HACKATHON_LOG.md` — current phase status, submission checklist, milestone history, and freeze tracking notes
-- `FUTURE_PLAN.md` — version-targeted roadmap (released through `v0.4.0`; active forward-planning target is `v0.5.0`)
+- `FUTURE_PLAN.md` — version-targeted roadmap (released through `v0.5.1`; active forward-planning target is `v0.5.2`)
 - `UI_PLAN.md` — UI maturity plan, principles, and weekly tracking through submission
 - `AGENT_HANDOFF_CONTEXT_MINISPEC.md` — draft design for Activity Detail `Copy Context` + optional `Assign to Agent` handoff integration
 - `GH_AW_IMPLEMENTATION_TRACKER.md` — gh-aw research summary, Layer 1/2 checklists, decision log, and evidence

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,8 +4,11 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>PipelineHealer - Self-Healing CI/CD</title>
-    <meta name="description" content="AI-powered self-healing CI/CD agent that automatically diagnoses and fixes pipeline failures" />
+    <title>PipelineHealer - OSS-First Pipeline Remediation Platform</title>
+    <meta
+      name="description"
+      content="Policy-aware pipeline remediation with operator-visible diagnosis, governed remediation paths, and deployment-managed outbound integrations."
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -28,6 +28,14 @@ export interface DashboardStats {
   last_updated: string
 }
 
+export interface ServiceHealth {
+  service: string
+  version: string
+  status: string
+  environment: string
+  storage_backend: string
+}
+
 export interface Diagnosis {
   failure_type: string
   diagnosis_source?: 'pattern' | 'llm'
@@ -504,6 +512,7 @@ async function fetchJson<T>(path: string, options?: ApiRequestOptions): Promise<
 }
 
 export const api = {
+  getServiceHealth: () => fetchJson<ServiceHealth>('/health'),
   getStats: () => fetchJson<DashboardStats>('/api/stats'),
   getSettings: (adminKey?: string) =>
     fetchJson<AppSettings>('/api/settings', { adminKey }),

--- a/frontend/src/buildInfo.ts
+++ b/frontend/src/buildInfo.ts
@@ -1,0 +1,4 @@
+import packageJson from '../package.json'
+
+export const FRONTEND_VERSION = String(packageJson.version || '0.0.0')
+export const FRONTEND_RELEASE_TAG = `v${FRONTEND_VERSION}`

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,4 +1,5 @@
 import { Link, Outlet, useLocation } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
 import {
   Activity,
   LayoutDashboard,
@@ -10,6 +11,8 @@ import {
 import clsx from "clsx";
 import { useEffect, useState } from "react";
 
+import { api } from "@/api/client";
+import { FRONTEND_RELEASE_TAG, FRONTEND_VERSION } from "@/buildInfo";
 import { Button } from "@/components/ui/button";
 import {
   Sheet,
@@ -27,6 +30,47 @@ const navigation = [
   { name: "Control Center", href: "/app/control-center", icon: ShieldCheck },
   { name: "Settings", href: "/app/settings", icon: Settings },
 ];
+
+function ReleaseStatus() {
+  const { data, isLoading } = useQuery({
+    queryKey: ["service-health"],
+    queryFn: api.getServiceHealth,
+    staleTime: 60_000,
+    refetchInterval: 120_000,
+    refetchOnWindowFocus: false,
+    retry: 1,
+  });
+
+  const apiVersion = String(data?.version || "").trim();
+  const versionsAligned = Boolean(apiVersion) && apiVersion === FRONTEND_VERSION;
+
+  let title = `UI ${FRONTEND_RELEASE_TAG}`;
+  let detail = "API version unavailable";
+  let toneClass = "text-[var(--ph-muted)]";
+
+  if (isLoading) {
+    detail = "Checking deployed backend version";
+  } else if (apiVersion && versionsAligned) {
+    title = `Release ${FRONTEND_RELEASE_TAG}`;
+    detail = `API ${FRONTEND_RELEASE_TAG} aligned`;
+    toneClass = "text-[var(--ph-success)]";
+  } else if (apiVersion) {
+    detail = `API v${apiVersion} differs from UI ${FRONTEND_RELEASE_TAG}`;
+    toneClass = "text-[var(--ph-warning)]";
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-[var(--ph-muted)]">
+          Release
+        </span>
+        <span className="text-xs font-semibold text-[var(--ph-text)]">{title}</span>
+      </div>
+      <p className={clsx("text-xs", toneClass)}>{detail}</p>
+    </div>
+  );
+}
 
 export default function Layout() {
   const location = useLocation();
@@ -105,6 +149,9 @@ export default function Layout() {
             <p className="mt-1 text-xs text-[var(--ph-muted)]">
               GitHub Actions and Jenkins bridge today.
             </p>
+            <div className="mt-3 border-t border-[var(--ph-border)] pt-3">
+              <ReleaseStatus />
+            </div>
           </div>
         </div>
       </div>
@@ -182,6 +229,9 @@ export default function Layout() {
                 );
               })}
             </nav>
+            <div className="mt-6 border-t border-[var(--ph-border)] pt-4">
+              <ReleaseStatus />
+            </div>
           </SheetContent>
         </Sheet>
       </div>

--- a/integrations/azure-function-agent-handoff/README.md
+++ b/integrations/azure-function-agent-handoff/README.md
@@ -1,6 +1,6 @@
 # PipelineHealer Agent Handoff Receiver
 
-<!-- LAST_VERIFIED: fadd4cf -->
+<!-- LAST_VERIFIED: fa18d60 -->
 
 Minimal Azure Functions app used as the deployment-facing boundary for Assign-to-Agent webhook delivery.
 
@@ -14,9 +14,9 @@ Current `BL-052` scope:
 - first sink types: `webhook`, `rocketchat_webhook`, `slack_webhook`, `teams_webhook`, `email`
 - non-fatal delivery behavior so the receiver can acknowledge the handoff even if one notification target fails
 
-Planned follow-on:
-- richer formatting/interaction features for chat sinks
-- richer operator status surfacing for downstream notification dependencies
+Current formatting posture:
+- chat and email sinks now prioritize diagnosis, remediation outcome, and action links over raw JSON metadata
+- delivery/request identifiers are kept as footer-level metadata instead of the primary message body
 
 Routes:
 - `GET /api/healthz` (`anonymous`)

--- a/integrations/azure-function-agent-handoff/shared.py
+++ b/integrations/azure-function-agent-handoff/shared.py
@@ -74,6 +74,20 @@ def activity_summary(payload: dict[str, Any]) -> dict[str, str]:
     }
 
 
+def handoff_summary(payload: dict[str, Any]) -> dict[str, Any]:
+    summary = coerce_dict(payload.get("summary"))
+    return {
+        "activity_url": str(summary.get("activity_url", "") or "").strip(),
+        "root_cause": str(summary.get("root_cause", "") or "").strip(),
+        "suggested_fix": str(summary.get("suggested_fix", "") or "").strip(),
+        "remediation_action": str(summary.get("remediation_action", "") or "").strip(),
+        "issue_url": str(summary.get("issue_url", "") or "").strip(),
+        "pr_url": str(summary.get("pr_url", "") or "").strip(),
+        "error_message": str(summary.get("error_message", "") or "").strip(),
+        "remediation_success": summary.get("remediation_success"),
+    }
+
+
 def json_response(body: dict[str, Any], status_code: int = 200) -> func.HttpResponse:
     return func.HttpResponse(
         json.dumps(body),
@@ -350,13 +364,38 @@ def _webhook_payload(payload: dict[str, Any], _target: NotificationTarget) -> di
     return payload
 
 
-def _chat_lines(payload: dict[str, Any]) -> list[str]:
+def _truncate_text(value: str, max_chars: int = 220) -> str:
+    text = " ".join(str(value or "").split()).strip()
+    if len(text) <= max_chars:
+        return text
+    return text[: max_chars - 3].rstrip() + "..."
+
+
+def _remediation_summary_text(payload: dict[str, Any]) -> str:
+    summary = handoff_summary(payload)
+    action = summary["remediation_action"].replace("_", " ").strip()
+    if not action:
+        return ""
+
+    message = f"Remediation: {action}"
+    if summary["remediation_success"] is True:
+        message += " succeeded"
+    elif summary["remediation_success"] is False:
+        message += " failed"
+
+    if summary["error_message"]:
+        message += f" ({_truncate_text(summary['error_message'], 140)})"
+    return message
+
+
+def _operator_lines(payload: dict[str, Any]) -> list[str]:
     summary = activity_summary(payload)
+    handoff = handoff_summary(payload)
     request_id = str(payload.get("request_id", "")).strip()
     normalized_event_type = event_type(payload)
 
     lines = [
-        "PipelineHealer handoff received",
+        "PipelineHealer handoff requested",
         f"Event: {normalized_event_type}",
         f"Repository: {summary['repository'] or 'n/a'}",
         f"Workflow: {summary['workflow_name'] or 'n/a'}",
@@ -365,45 +404,57 @@ def _chat_lines(payload: dict[str, Any]) -> list[str]:
     ]
     if summary["failure_type"]:
         lines.append(f"Failure Type: {summary['failure_type']}")
+    if handoff["root_cause"]:
+        lines.extend(["", f"Diagnosis: {_truncate_text(handoff['root_cause'], 280)}"])
+    if handoff["suggested_fix"]:
+        lines.append(f"Suggested fix: {_truncate_text(handoff['suggested_fix'], 280)}")
+    remediation = _remediation_summary_text(payload)
+    if remediation:
+        lines.extend(["", remediation])
+    link_lines = [
+        ("Open activity", handoff["activity_url"]),
+        ("Open issue", handoff["issue_url"]),
+        ("Open PR", handoff["pr_url"]),
+    ]
+    rendered_links = [f"{label}: {url}" for label, url in link_lines if url]
+    if rendered_links:
+        lines.extend(["", *rendered_links])
     if request_id:
-        lines.append(f"Request ID: {request_id}")
+        lines.extend(["", f"Request ID: {request_id}"])
     return lines
 
 
 def _rocketchat_payload(payload: dict[str, Any], target: NotificationTarget) -> dict[str, Any]:
     summary = activity_summary(payload)
     delivery_id = str(payload.get("delivery_id", "")).strip()
-    normalized_event_type = event_type(payload)
-
-    # Keep the chat payload short and human-readable, while preserving the original
-    # event contract in a structured attachment for downstream tooling.
-    lines = _chat_lines(payload)
+    lines = _operator_lines(payload)
     lines[0] = ":robot_face: " + lines[0]
 
-    return {
+    attachment_lines = []
+    if target.name:
+        attachment_lines.append(f"Target: {target.name}")
+    if delivery_id:
+        attachment_lines.append(f"Delivery ID: {delivery_id}")
+
+    body = {
         "alias": "PipelineHealer",
         "text": "\n".join(lines),
-        "attachments": [
-            {
-                "title": target.name,
-                "text": json.dumps(
-                    {
-                        "event_type": normalized_event_type,
-                        "delivery_id": delivery_id,
-                        "activity_id": summary["activity_id"],
-                        "repository": summary["repository"],
-                        "workflow_name": summary["workflow_name"],
-                    }
-                ),
-            }
-        ],
     }
+    if attachment_lines:
+        body["attachments"] = [
+            {
+                "title": summary["activity_id"] or target.name,
+                "text": "\n".join(attachment_lines),
+            }
+        ]
+    return body
 
 
 def _slack_payload(payload: dict[str, Any], _target: NotificationTarget) -> dict[str, Any]:
-    lines = _chat_lines(payload)
     summary = activity_summary(payload)
+    handoff = handoff_summary(payload)
     request_id = str(payload.get("request_id", "")).strip()
+    delivery_id = str(payload.get("delivery_id", "")).strip()
     normalized_event_type = event_type(payload)
 
     # Slack incoming webhooks accept normal message text plus Block Kit.
@@ -416,26 +467,55 @@ def _slack_payload(payload: dict[str, Any], _target: NotificationTarget) -> dict
     if summary["failure_type"]:
         fields.append({"type": "mrkdwn", "text": f"*Failure Type*\n{summary['failure_type']}"})
 
-    # Keep the context block for supplemental metadata only so the main activity
-    # facts are not duplicated below the fields grid.
-    context_lines = [f"Event: {normalized_event_type}"]
-    if request_id:
-        context_lines.append(f"Request ID: {request_id}")
-
-    return {
-        "text": " | ".join(lines),
-        "blocks": [
+    blocks: list[dict[str, Any]] = [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "*PipelineHealer handoff requested*",
+            },
+        },
+        {
+            "type": "section",
+            "fields": fields,
+        },
+    ]
+    if handoff["root_cause"]:
+        blocks.append(
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "*PipelineHealer handoff received*",
+                    "text": f"*Diagnosis*\n{_truncate_text(handoff['root_cause'], 280)}",
                 },
-            },
+            }
+        )
+    remediation = _remediation_summary_text(payload)
+    if remediation:
+        blocks.append(
             {
                 "type": "section",
-                "fields": fields,
-            },
+                "text": {"type": "mrkdwn", "text": f"*Remediation*\n{remediation}"},
+            }
+        )
+
+    context_lines = [f"Event: {normalized_event_type}"]
+    for label, url in (
+        ("Activity", handoff["activity_url"]),
+        ("Issue", handoff["issue_url"]),
+        ("PR", handoff["pr_url"]),
+    ):
+        if url:
+            context_lines.append(f"{label}: {url}")
+    if request_id:
+        context_lines.append(f"Request ID: {request_id}")
+    if delivery_id:
+        context_lines.append(f"Delivery ID: {delivery_id}")
+
+    return {
+        "text": "\n".join(_operator_lines(payload)),
+        "blocks": [
+            *blocks,
             {
                 "type": "context",
                 "elements": [{"type": "mrkdwn", "text": line} for line in context_lines],
@@ -446,7 +526,9 @@ def _slack_payload(payload: dict[str, Any], _target: NotificationTarget) -> dict
 
 def _teams_payload(payload: dict[str, Any], _target: NotificationTarget) -> dict[str, Any]:
     summary = activity_summary(payload)
+    handoff = handoff_summary(payload)
     request_id = str(payload.get("request_id", "")).strip()
+    delivery_id = str(payload.get("delivery_id", "")).strip()
     normalized_event_type = event_type(payload)
 
     facts = [
@@ -460,6 +542,53 @@ def _teams_payload(payload: dict[str, Any], _target: NotificationTarget) -> dict
         facts.append({"title": "Failure Type", "value": summary["failure_type"]})
     if request_id:
         facts.append({"title": "Request ID", "value": request_id})
+    if delivery_id:
+        facts.append({"title": "Delivery ID", "value": delivery_id})
+
+    body: list[dict[str, Any]] = [
+        {
+            "type": "TextBlock",
+            "text": "PipelineHealer handoff requested",
+            "weight": "Bolder",
+            "size": "Medium",
+            "wrap": True,
+        },
+        {
+            "type": "FactSet",
+            "facts": facts,
+        },
+    ]
+    if handoff["root_cause"]:
+        body.append(
+            {
+                "type": "TextBlock",
+                "text": f"Diagnosis: {_truncate_text(handoff['root_cause'], 280)}",
+                "wrap": True,
+            }
+        )
+    remediation = _remediation_summary_text(payload)
+    if remediation:
+        body.append(
+            {
+                "type": "TextBlock",
+                "text": remediation,
+                "wrap": True,
+            }
+        )
+    link_lines = [
+        f"[Open activity]({handoff['activity_url']})" if handoff["activity_url"] else "",
+        f"[Open issue]({handoff['issue_url']})" if handoff["issue_url"] else "",
+        f"[Open PR]({handoff['pr_url']})" if handoff["pr_url"] else "",
+    ]
+    rendered_links = [line for line in link_lines if line]
+    if rendered_links:
+        body.append(
+            {
+                "type": "TextBlock",
+                "text": " | ".join(rendered_links),
+                "wrap": True,
+            }
+        )
 
     # Teams Incoming Webhooks accept a message wrapper containing an Adaptive Card attachment.
     return {
@@ -472,19 +601,7 @@ def _teams_payload(payload: dict[str, Any], _target: NotificationTarget) -> dict
                     "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
                     "type": "AdaptiveCard",
                     "version": "1.2",
-                    "body": [
-                        {
-                            "type": "TextBlock",
-                            "text": "PipelineHealer handoff received",
-                            "weight": "Bolder",
-                            "size": "Medium",
-                            "wrap": True,
-                        },
-                        {
-                            "type": "FactSet",
-                            "facts": facts,
-                        },
-                    ],
+                    "body": body,
                 },
             }
         ],
@@ -509,20 +626,22 @@ def _email_subject(payload: dict[str, Any], target: NotificationTarget) -> str:
 
 def _email_body(payload: dict[str, Any]) -> str:
     summary = activity_summary(payload)
+    handoff = handoff_summary(payload)
     request_id = str(payload.get("request_id", "")).strip()
     delivery_id = str(payload.get("delivery_id", "")).strip()
     context = str(payload.get("context", "")).strip()
     excerpt = context[:1200].strip()
 
-    lines = _chat_lines(payload)
+    lines = _operator_lines(payload)
     if delivery_id:
         lines.append(f"Delivery ID: {delivery_id}")
     if request_id:
         lines.append(f"Request ID: {request_id}")
-    lines.append("")
-    lines.append("This email was sent by the PipelineHealer outbound integration gateway.")
+    if handoff["activity_url"]:
+        lines.extend(["", f"Open activity: {handoff['activity_url']}"])
+    lines.extend(["", "This email was sent by the PipelineHealer outbound integration gateway."])
     if summary["failure_type"]:
-        lines.append("Review the linked activity in PipelineHealer for full evidence and remediation context.")
+        lines.append("Review the linked activity for full evidence and remediation context.")
     if excerpt:
         lines.extend(["", "Context excerpt:", excerpt])
         if len(context) > len(excerpt):


### PR DESCRIPTION
## Summary
- improve handoff notification payloads so Rocket.Chat, Slack, Teams, and email prioritize diagnosis, remediation, and action links over raw transport metadata
- surface the deployed UI/API release version in the shell and align backend health/version reporting with packaged releases
- refresh stale public docs and examples so README and API docs match the current release line and health contract

## Testing
- cd backend && pytest -q tests/test_agent_handoff.py tests/test_agent_handoff_receiver.py tests/test_phase2_security.py
- cd frontend && bun run lint
- cd frontend && bun run build
- git diff --check
