### PR TITLE
docs: fix protected-branch review workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ When `main` is protected, use this delivery pattern instead of trying to push di
 
 1. Create a branch from current `main` (`release/vX.Y.Z` for release work, otherwise a task branch).
 2. Push the branch and open a PR with a verification summary.
-3. Request GitHub Copilot review by commenting `@copilot review` on the PR.
+3. Wait for the repository's attached review agents and bots to publish their review comments on the PR.
 4. Address review comments in code/docs, resolve review threads, and re-run the relevant checks.
 5. Add a short final PR comment summarizing what changed, what was verified, and any residual release/deploy nuance.
 6. Merge the PR, delete the branch, and sync local `main` back to `origin/main`.
@@ -104,7 +104,7 @@ When `main` is protected, use this delivery pattern instead of trying to push di
 For release cuts that must deploy before protected-branch merge completes:
 
 1. Prepare the release commit on the release branch.
-2. Tag that exact release-branch commit (`vX.Y.Z`) and push the tag.
+2. Tag that exact release-branch commit (`vX.Y.Z`) and push the tag (for example: `git tag -a vX.Y.Z -m "Release vX.Y.Z"` then `git push origin vX.Y.Z`).
 3. Wait for the GitHub `Release` workflow to succeed.
 4. Deploy to Azure Container Apps with `bash scripts/ph.sh deploy:release --release-version vX.Y.Z`.
 5. Merge the PR afterward so protected `main` catches up to the already-deployed release commit.

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -1,6 +1,6 @@
 # Release Runbook
 
-<!-- LAST_VERIFIED: 9c4e889 -->
+<!-- LAST_VERIFIED: 5423515 -->
 
 End-to-end release procedure for PipelineHealer using the repo release helpers.
 
@@ -172,15 +172,15 @@ If `git push origin main --follow-tags` is blocked by branch protection, use a r
 git checkout -b release/vX.Y.Z
 git push origin release/vX.Y.Z
 gh pr create --base main --head release/vX.Y.Z --title "chore(release): vX.Y.Z"
-gh pr comment <pr-number> --body "@copilot review"
+git push origin vX.Y.Z
 ```
 
 Recommended sequence when branch protection is active:
 
 1. Push the branch first.
-2. Open the PR and request Copilot review.
+2. Open the PR and wait for the repository's attached review agents/bots to publish their review comments.
 3. Address review comments and resolve review threads before merge.
-4. If you need deployment before PR merge, push the release tag from the release-branch commit and continue with release verification + Azure promotion.
+4. If you need deployment before PR merge, push the release tag from the release-branch commit to `origin` (for example: `git push origin vX.Y.Z`) and continue with release verification + Azure promotion.
 5. Merge the PR after checks are green, then delete the branch and sync local `main`.
 
 Practical note:


### PR DESCRIPTION
## Summary
- remove the manual Copilot-mention step from the documented PR flow
- make the protected-branch release tag push explicit and shell-safe
- align AGENTS.md and the release runbook with the actual review/deploy sequence

## Why
PR #102 was merged before its automated review comments were reflected in the docs. This follow-up incorporates those findings and corrects the process guidance.

## Verification
- reviewed bot comments on merged PR #102
- updated AGENTS.md and docs/RELEASE_RUNBOOK.md to address those findings