### PR TITLE
Improve deterministic suggestions and repo drilldown UX

### DIFF
--- a/backend/src/agents/diagnosis.py
+++ b/backend/src/agents/diagnosis.py
@@ -376,7 +376,8 @@ Be specific about:
                     flags=re.IGNORECASE,
                 )
                 if python_missing_match:
-                    package_name = python_missing_match.group(1)
+                    raw_module = python_missing_match.group(1)
+                    package_name = raw_module.split(".")[0] if raw_module else ""
 
                 if not package_name:
                     package_match = re.search(
@@ -399,12 +400,26 @@ Be specific about:
 
                 # Infer package manager from the matched pattern/context, not from incidental words.
                 # This keeps Node "Cannot find module ..." from defaulting to pip.
-                package_manager = "npm" if (
-                    "npm" in pattern
-                    or "npm" in error_text.lower()
-                    or "bun" in error_text.lower()
-                    or "Cannot find module" in pattern
-                ) else "pip"
+                normalized_error_text = error_text.lower()
+                normalized_description = description.lower()
+                package_manager = (
+                    "npm"
+                    if (
+                        "npm" in pattern
+                        or "npm" in normalized_error_text
+                        or "bun" in normalized_error_text
+                        or "Cannot find module" in pattern
+                    )
+                    else "pip"
+                    if (
+                        "python" in normalized_description
+                        or "pip" in normalized_description
+                        or "modulenotfounderror" in normalized_error_text
+                    )
+                    else "docker"
+                    if "docker" in normalized_description or "manifest" in normalized_description
+                    else "generic"
+                )
 
                 return Diagnosis(
                     failure_type=FailureType.DEPENDENCY,
@@ -659,7 +674,19 @@ Be specific about:
         """Build a dependency fix suggestion from the matched package context."""
         normalized_manager = package_manager.strip().lower()
         normalized_package = package_name.strip()
-        is_version_conflict = "conflict" in description.lower() or "resolve" in description.lower()
+        normalized_description = description.lower()
+        is_version_conflict = any(
+            marker in normalized_description
+            for marker in (
+                "conflict",
+                "resolve",
+                "resolution",
+                "eresolve",
+                "peer dep",
+                "peer dependency",
+                "unable to resolve dependency tree",
+            )
+        )
 
         if normalized_manager == "npm":
             if normalized_package:
@@ -671,20 +698,34 @@ Be specific about:
                 return f"Add `{normalized_package}` to package.json and refresh the lockfile."
             return "Update package.json dependencies and refresh the lockfile."
 
-        if normalized_package:
-            if is_version_conflict:
+        if normalized_manager in {"pip", "uv", "python"}:
+            if normalized_package:
+                if is_version_conflict:
+                    return (
+                        f"Update Python dependency `{normalized_package}` in pyproject.toml or "
+                        "requirements.txt to a compatible version and reinstall dependencies."
+                    )
                 return (
-                    f"Update Python dependency `{normalized_package}` in pyproject.toml or "
-                    "requirements.txt to a compatible version and reinstall dependencies."
+                    f"Add Python dependency `{normalized_package}` in pyproject.toml or "
+                    "requirements.txt and reinstall dependencies."
                 )
-            return (
-                f"Add Python dependency `{normalized_package}` in pyproject.toml or "
-                "requirements.txt and reinstall dependencies."
-            )
+            if is_version_conflict:
+                return "Update the dependency version constraint to a compatible release and reinstall."
+            return "Add the missing dependency to the project manifest and reinstall dependencies."
 
+        if normalized_manager == "docker":
+            if normalized_package:
+                return (
+                    f"Update the referenced image or package `{normalized_package}` to one that exists "
+                    "in the configured registry and re-run the workflow."
+                )
+            return "Update the referenced container image or registry path and re-run the workflow."
+
+        if normalized_package:
+            return f"Install or restore the missing package/resource `{normalized_package}` and re-run the workflow."
         if is_version_conflict:
-            return "Update the dependency version constraint to a compatible release and reinstall."
-        return "Add the missing dependency to the project manifest and reinstall dependencies."
+            return "Update the conflicting dependency or package version to a compatible release and re-run the workflow."
+        return "Install or restore the missing package/resource and re-run the workflow."
 
     def _build_classification_details(
         self,

--- a/backend/tests/test_diagnosis.py
+++ b/backend/tests/test_diagnosis.py
@@ -57,6 +57,26 @@ class TestPatternBasedDiagnosis:
             "and reinstall dependencies."
         )
 
+    def test_detect_python_submodule_not_found_normalizes_package_name(self) -> None:
+        """Top-level import names should drive Python package suggestions."""
+        log_analysis = LogAnalysis(
+            job_id=1,
+            job_name="test",
+            raw_logs="ModuleNotFoundError: No module named 'requests.adapters'",
+            error_lines=["ModuleNotFoundError: No module named 'requests.adapters'"],
+            summary="Import failed",
+        )
+
+        diagnosis = self.agent._pattern_based_diagnosis([log_analysis])
+
+        assert diagnosis is not None
+        assert diagnosis.failure_type == FailureType.DEPENDENCY
+        assert diagnosis.error_details.get("package_name") == "requests"
+        assert diagnosis.suggested_fix == (
+            "Add Python dependency `requests` in pyproject.toml or requirements.txt "
+            "and reinstall dependencies."
+        )
+
     def test_detect_node_missing_module_suggests_manifest_update(self) -> None:
         """Test that missing Node modules get a package.json-specific suggestion."""
         log_analysis = LogAnalysis(
@@ -75,6 +95,41 @@ class TestPatternBasedDiagnosis:
         assert diagnosis.error_details.get("package_manager") == "npm"
         assert diagnosis.suggested_fix == (
             "Add `left-pad` to package.json and refresh the lockfile."
+        )
+
+    def test_detect_npm_resolution_conflict_suggests_compatible_version(self) -> None:
+        """ERESOLVE signatures should produce version-conflict guidance."""
+        log_analysis = LogAnalysis(
+            job_id=1,
+            job_name="build",
+            raw_logs="npm ERR! ERESOLVE unable to resolve dependency tree",
+            error_lines=["npm ERR! ERESOLVE unable to resolve dependency tree"],
+            summary="Dependency resolution failed",
+        )
+
+        diagnosis = self.agent._pattern_based_diagnosis([log_analysis])
+
+        assert diagnosis is not None
+        assert diagnosis.failure_type == FailureType.DEPENDENCY
+        assert diagnosis.suggested_fix == "Update package.json dependencies and refresh the lockfile."
+
+    def test_generic_missing_package_does_not_assume_python_manifest(self) -> None:
+        """Generic package errors should stay neutral instead of pointing at pyproject.toml."""
+        log_analysis = LogAnalysis(
+            job_id=1,
+            job_name="build",
+            raw_logs="Package 'libpq-dev' was not found",
+            error_lines=["Package 'libpq-dev' was not found"],
+            summary="System package missing",
+        )
+
+        diagnosis = self.agent._pattern_based_diagnosis([log_analysis])
+
+        assert diagnosis is not None
+        assert diagnosis.failure_type == FailureType.DEPENDENCY
+        assert diagnosis.error_details.get("package_manager") == "generic"
+        assert diagnosis.suggested_fix == (
+            "Install or restore the missing package/resource `libpq-dev` and re-run the workflow."
         )
 
     def test_detect_eslint_error(self) -> None:

--- a/frontend/src/pages/Activities.tsx
+++ b/frontend/src/pages/Activities.tsx
@@ -47,6 +47,7 @@ export default function Activities() {
     failure_type: failureTypeParam,
     limit: 50,
   })
+  const [repositoryDraft, setRepositoryDraft] = useState(repositoryParam)
   const [highlightedActivityId, setHighlightedActivityId] = useState<string | null>(null)
 
   const { data: activities, isLoading, refetch, isFetching } = useQuery({
@@ -78,6 +79,29 @@ export default function Activities() {
   }, [failureTypeParam, repositoryParam, statusParam])
 
   useEffect(() => {
+    setRepositoryDraft(repositoryParam)
+  }, [repositoryParam])
+
+  useEffect(() => {
+    if (repositoryDraft === filters.repository) {
+      return
+    }
+
+    const timer = window.setTimeout(() => {
+      setFilters((prev) => ({ ...prev, repository: repositoryDraft }))
+      const nextParams = new URLSearchParams(searchParams)
+      if (repositoryDraft) {
+        nextParams.set('repository', repositoryDraft)
+      } else {
+        nextParams.delete('repository')
+      }
+      setSearchParams(nextParams, { replace: true })
+    }, 300)
+
+    return () => window.clearTimeout(timer)
+  }, [filters.repository, repositoryDraft, searchParams, setSearchParams])
+
+  useEffect(() => {
     if (!focusedActivityId || !activities || !hasFocusedActivity) return
 
     setHighlightedActivityId(focusedActivityId)
@@ -102,7 +126,7 @@ export default function Activities() {
     }
   }
 
-  const updateFilter = (key: 'repository' | 'status' | 'failure_type', value: string) => {
+  const updateFilter = (key: 'status' | 'failure_type', value: string) => {
     setFilters((prev) => ({ ...prev, [key]: value }))
 
     const nextParams = new URLSearchParams(searchParams)
@@ -164,8 +188,8 @@ export default function Activities() {
           <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:gap-4">
             <Filter className="h-5 w-5 text-[var(--ph-muted)]" />
             <Input
-              value={filters.repository}
-              onChange={(event) => updateFilter('repository', event.target.value)}
+              value={repositoryDraft}
+              onChange={(event) => setRepositoryDraft(event.target.value)}
               className="lg:w-[22rem]"
               placeholder="Filter by repository (owner/repo)"
               aria-label="Filter by repository"
@@ -203,7 +227,7 @@ export default function Activities() {
               </SelectContent>
             </Select>
             {filters.repository && (
-              <Button variant="ghost" size="sm" onClick={() => updateFilter('repository', '')}>
+              <Button variant="ghost" size="sm" onClick={() => setRepositoryDraft('')}>
                 Clear repo
               </Button>
             )}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -661,10 +661,10 @@ export default function Dashboard() {
                     fill="#3b82f6"
                     radius={[4, 4, 0, 0]}
                     cursor="pointer"
-                    onClick={(data) =>
+                    onClick={(data: { payload?: { fullName?: string } } | undefined) =>
                       handleRepositoryBarClick(
-                        data && typeof data.fullName === "string"
-                          ? data.fullName
+                        typeof data?.payload?.fullName === "string"
+                          ? data.payload.fullName
                           : undefined,
                       )
                     }


### PR DESCRIPTION
## Summary
- replace generic dependency suggestions with package-manager-specific guidance built from structured extraction
- add regression tests for Python and Node missing-module detection
- make the dashboard top-repositories bar chart navigate to Activities filtered to the clicked repository and expose that filter in the Activities page

## Verification
- `pytest -q backend/tests/test_diagnosis.py`
- `bun run build` (from the installed frontend workspace)

Refs #111