### PR TITLE
v0.6.0: add structured deterministic diagnosis details

### DIFF
--- a/backend/src/agents/diagnosis.py
+++ b/backend/src/agents/diagnosis.py
@@ -17,6 +17,7 @@ from ..models import (
     LogAnalysis,
 )
 from ..tools.github_tools import GitHubTools
+from ..tools.lint_autofix import lint_autofix_command
 from .base import create_cloud_agent, get_agent_prompt
 
 logger = logging.getLogger(__name__)
@@ -462,12 +463,13 @@ Be specific about:
 
         for pattern, linter, description, is_missing_config in lint_patterns:
             if re.search(pattern, error_text, re.IGNORECASE):
-                autofix_command = self._lint_autofix_command(linter)
+                autofix_command = lint_autofix_command(linter)
+                is_auto_fixable = is_missing_config or bool(autofix_command)
                 return Diagnosis(
                     failure_type=FailureType.LINT,
                     confidence=0.9,
                     root_cause=description,
-                    is_auto_fixable=True,
+                    is_auto_fixable=is_auto_fixable,
                     suggested_fix=self._build_lint_suggested_fix(
                         linter=linter,
                         is_missing_config=is_missing_config,
@@ -811,16 +813,6 @@ Be specific about:
         payload["classification_pattern"] = pattern
         return payload
 
-    def _lint_autofix_command(self, linter: str) -> str:
-        commands = {
-            "eslint": "npx eslint --fix .",
-            "prettier": "npx prettier --write .",
-            "black": "black .",
-            "ruff": "ruff check --fix . && ruff format .",
-            "flake8": "",
-        }
-        return commands.get(linter, "")
-
     def _build_lint_suggested_fix(
         self,
         *,
@@ -830,7 +822,7 @@ Be specific about:
     ) -> str:
         if is_missing_config and missing_file:
             return f"Add `{missing_file}` so {linter} can load its required configuration."
-        autofix_command = self._lint_autofix_command(linter)
+        autofix_command = lint_autofix_command(linter)
         if autofix_command:
             return f"Run `{autofix_command}` locally and commit the resulting lint fixes."
         return f"Fix the reported {linter} violations and re-run the workflow."
@@ -897,7 +889,11 @@ Be specific about:
         text = error_text.lower()
         if "no space left on device" in text or "disk space" in text:
             return "disk"
-        if "signal 9" in text or "killed" in text or "oom" in text:
+        if (
+            "oom" in text
+            or "out of memory" in text
+            or ("signal 9" in text and "memory" in text)
+        ):
             return "memory"
         if "network" in text or "connection reset" in text:
             return "network"

--- a/backend/src/tools/fix_generators.py
+++ b/backend/src/tools/fix_generators.py
@@ -7,6 +7,7 @@ from enum import StrEnum
 from typing import Any
 
 from ..models import Diagnosis, FailureType, RemediationAction, RemediationPlan
+from .lint_autofix import lint_autofix_command
 
 logger = logging.getLogger(__name__)
 
@@ -290,12 +291,7 @@ class FixGenerators:
                     "  },\n"
                     "];"
                 )
-            fix_cmd = {
-                "prettier": "npx prettier --write .",
-                "eslint": "npx eslint --fix .",
-                "black": "black .",
-                "ruff": "ruff check --fix . && ruff format .",
-            }.get(linter)
+            fix_cmd = lint_autofix_command(linter)
             if fix_cmd:
                 return f"Run locally:\n{fix_cmd}"
 
@@ -498,15 +494,7 @@ PipelineHealer automated analysis
             )
 
         # For auto-fixable linters, suggest running the fix command
-        auto_fix_commands = {
-            "eslint": "npx eslint --fix .",
-            "prettier": "npx prettier --write .",
-            "black": "black .",
-            "ruff": "ruff check --fix . && ruff format .",
-            "isort": "isort .",
-        }
-
-        fix_command = auto_fix_commands.get(linter)
+        fix_command = lint_autofix_command(linter)
 
         if fix_command and diagnosis.is_auto_fixable:
             # Create a workflow that runs the fix

--- a/backend/src/tools/lint_autofix.py
+++ b/backend/src/tools/lint_autofix.py
@@ -1,0 +1,13 @@
+"""Shared deterministic lint autofix commands."""
+
+
+def lint_autofix_command(linter: str) -> str:
+    """Return the approved autofix command for a known linter."""
+    commands = {
+        "eslint": "npx eslint --fix .",
+        "prettier": "npx prettier --write .",
+        "black": "black .",
+        "ruff": "ruff check --fix . && ruff format .",
+        "isort": "isort .",
+    }
+    return commands.get(str(linter).strip().lower(), "")

--- a/backend/tests/test_diagnosis.py
+++ b/backend/tests/test_diagnosis.py
@@ -153,6 +153,25 @@ class TestPatternBasedDiagnosis:
             "Run `npx eslint --fix .` locally and commit the resulting lint fixes."
         )
 
+    def test_detect_flake8_error_is_not_auto_fixable(self) -> None:
+        """Flake8 violations should stay review-only without a deterministic autofix command."""
+        log_analysis = LogAnalysis(
+            job_id=1,
+            job_name="lint",
+            raw_logs="flake8 error: F401 imported but unused",
+            error_lines=["flake8 error: F401 imported but unused"],
+            summary="Linting failed",
+        )
+
+        diagnosis = self.agent._pattern_based_diagnosis([log_analysis])
+
+        assert diagnosis is not None
+        assert diagnosis.failure_type == FailureType.LINT
+        assert diagnosis.error_details.get("linter") == "flake8"
+        assert diagnosis.error_details.get("autofix_command") == ""
+        assert diagnosis.is_auto_fixable is False
+        assert diagnosis.suggested_fix == "Fix the reported flake8 violations and re-run the workflow."
+
     def test_detect_prettier_code_style_message(self) -> None:
         """Test detection of Prettier check output signature."""
         log_analysis = LogAnalysis(
@@ -297,6 +316,23 @@ class TestPatternBasedDiagnosis:
 
         assert diagnosis is not None
         assert diagnosis.failure_type == FailureType.TIMEOUT
+        assert diagnosis.error_details.get("likely_fix_kind") == "increase_timeout"
+
+    def test_detect_killed_timeout_without_memory_signal_stays_unknown(self) -> None:
+        """Generic killed logs should not be mislabeled as memory pressure."""
+        log_analysis = LogAnalysis(
+            job_id=1,
+            job_name="build",
+            raw_logs="Error: exceeded time limit of 15 minutes; process was killed",
+            error_lines=["Error: exceeded time limit of 15 minutes; process was killed"],
+            summary="Time limit exceeded",
+        )
+
+        diagnosis = self.agent._pattern_based_diagnosis([log_analysis])
+
+        assert diagnosis is not None
+        assert diagnosis.failure_type == FailureType.TIMEOUT
+        assert diagnosis.error_details.get("resource_signal") == "unknown"
         assert diagnosis.error_details.get("likely_fix_kind") == "increase_timeout"
 
     def test_timeout_setting_not_misclassified(self) -> None:

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # PipelineHealer API Reference
 
-<!-- LAST_VERIFIED: f8910da -->
+<!-- LAST_VERIFIED: 18c11bd -->
 
 This document describes the PipelineHealer backend REST API, authentication model, request/response contracts, and best practices.
 
@@ -294,7 +294,7 @@ Returns activity records with optional filtering and pagination.
         "classification_family": "dependency",
         "classification_pattern": "Cannot find module"
       },
-      "suggested_fix": "Add `left-pad` to package.json and refresh the lockfile.",
+      "suggested_fix": "Update or install the missing dependency.",
       "is_auto_fixable": true
     },
     "failure_context": {
@@ -1255,7 +1255,7 @@ Common examples:
 - `dependency`: `package_name`, `package_manager`, `manifest_file`, `required_version`
 - `lint`: `linter`, `missing_file`, `config_file`, `autofix_command`, `violations`
 - `test`: `test_framework`, `failed_tests`, `test_errors`, `failure_scope`, `suspected_files`
-- `timeout`: `timed_out_job`, `timed_out_step`, `timeout_minutes`, `suggested_timeout`, `resource_signal`
+- `timeout`: `timed_out_job`, `timed_out_step`, `timeout_minutes`, `suggested_timeout`, `resource_signal`, `likely_fix_kind`
 - `build_config`: `missing_env_vars`, `workflow_permissions_fix`, `permissions`, `misconfiguration_kind`, `config_file`
 
 ### FailureContext (object)


### PR DESCRIPTION
## Summary
- enrich deterministic diagnosis paths for lint, test, timeout, and build-config failures with typed `error_details`
- replace generic deterministic suggestions with more specific, evidence-backed guidance for those failure classes
- update the API reference to document richer structured diagnosis details

## Scope
- target version: `v0.6.0`
- change type: `minor`
- changelog section: `Changed`
- implementation slice: deterministic extraction and serialization (follow-on from #113)

## Verification
- `pytest -q backend/tests/test_diagnosis.py`
- `pytest -q backend/tests/test_phase1_5_demo_mode.py backend/tests/test_phase1_correctness.py`

## Notes
- this intentionally stops before remediation-generator alignment and bounded patch drafting
- those follow in later `v0.6.0` slices from the architecture plan in #113

Refs #111
Refs #113