### PR TITLE
Harden generated issue lifecycle hygiene

### DIFF
--- a/backend/src/agents/remediation.py
+++ b/backend/src/agents/remediation.py
@@ -320,7 +320,11 @@ class RemediationAgent:
 
         # Apply the remediation
         try:
-            result = await self._apply_remediation(plan, repository_info, workflow_run_id)
+            result = await self._apply_remediation(
+                plan,
+                repository_info,
+                workflow_run_id,
+            )
             return result
         except Exception as e:
             logger.exception(f"Failed to apply remediation: {e}")
@@ -368,11 +372,23 @@ class RemediationAgent:
                 workflow_run_id=workflow_run_id,
             )
         elif plan.action == RemediationAction.CREATE_ISSUE:
-            return await self._create_issue(plan, owner, repo, workflow_run_id)
+            return await self._create_issue(
+                plan,
+                owner,
+                repo,
+                workflow_run_id,
+                repository_info=repository_info,
+            )
         elif plan.action == RemediationAction.RETRY_WORKFLOW:
             return await self._retry_workflow(owner, repo, workflow_run_id)
         elif plan.action == RemediationAction.NOTIFY:
-            return await self._create_issue(plan, owner, repo, workflow_run_id)
+            return await self._create_issue(
+                plan,
+                owner,
+                repo,
+                workflow_run_id,
+                repository_info=repository_info,
+            )
         else:
             return RemediationResult(
                 success=False,
@@ -404,6 +420,15 @@ class RemediationAgent:
     @staticmethod
     def _fingerprint_marker(fingerprint: str) -> str:
         return f"<!-- pipelinehealer:fingerprint:{fingerprint} -->"
+
+    @staticmethod
+    def _workflow_run_marker(workflow_run_id: int) -> str:
+        return f"<!-- pipelinehealer:workflow-run:{workflow_run_id} -->"
+
+    @staticmethod
+    def _generated_issue_kind_marker(kind: str) -> str:
+        normalized = re.sub(r"[^a-z0-9_-]+", "-", str(kind).strip().lower()) or "issue"
+        return f"<!-- pipelinehealer:generated-issue:{normalized} -->"
 
     @staticmethod
     def _extract_patch_drafting_trace(rendered_changes: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -512,6 +537,156 @@ class RemediationAgent:
             if marker in body and "auto-fix tracking" in title:
                 return issue
         return None
+
+    async def _find_existing_generated_issue(
+        self,
+        *,
+        owner: str,
+        repo: str,
+        marker: str,
+        workflow_run_id: int,
+        kind: str,
+        title: str,
+    ) -> dict[str, Any] | None:
+        """Find an existing open generated issue for this workflow run and artifact kind."""
+        run_marker = self._workflow_run_marker(workflow_run_id)
+        kind_marker = self._generated_issue_kind_marker(kind)
+        normalized_title = str(title or "").strip()
+        issues = await self._github_tools.list_issues(
+            owner=owner,
+            repo=repo,
+            state="open",
+            labels="pipelinehealer",
+            per_page=100,
+        )
+        for issue in issues:
+            body = str(issue.get("body", "") or "")
+            if marker in body:
+                return issue
+            issue_title = str(issue.get("title", "") or "").strip()
+            if run_marker in body and kind_marker in body and issue_title == normalized_title:
+                return issue
+        return None
+
+    async def _find_superseded_review_issues(
+        self,
+        *,
+        owner: str,
+        repo: str,
+        workflow_run_id: int,
+    ) -> list[dict[str, Any]]:
+        """Find open review-only generated issues for the same workflow run."""
+        run_marker = self._workflow_run_marker(workflow_run_id)
+        kind_marker = self._generated_issue_kind_marker("review")
+        issues = await self._github_tools.list_issues(
+            owner=owner,
+            repo=repo,
+            state="open",
+            labels="pipelinehealer",
+            per_page=100,
+        )
+        return [
+            issue
+            for issue in issues
+            if run_marker in str(issue.get("body", "") or "")
+            and kind_marker in str(issue.get("body", "") or "")
+        ]
+
+    async def _link_generated_issue_to_pull_requests(
+        self,
+        *,
+        owner: str,
+        repo: str,
+        issue_number: int,
+        issue_url: str,
+        pull_request_numbers: list[int],
+    ) -> list[int]:
+        """Append deterministic closure references to active PRs for this generated issue."""
+        linked: list[int] = []
+        marker = f"<!-- pipelinehealer:linked-issue:{issue_number} -->"
+        for pr_number in pull_request_numbers:
+            try:
+                pr = await self._github_tools.get_pull_request(owner, repo, pr_number)
+                current_body = str(pr.get("body", "") or "").rstrip()
+                if marker in current_body or f"Closes #{issue_number}" in current_body:
+                    linked.append(pr_number)
+                    continue
+
+                appended = (
+                    ("\n\n" if current_body else "")
+                    + "PipelineHealer linked issue:\n"
+                    + f"Closes #{issue_number}\n"
+                    + f"{marker}\n"
+                )
+                updated_body = f"{current_body}{appended}" if current_body else appended.lstrip()
+                await self._github_tools.update_pull_request(
+                    owner=owner,
+                    repo=repo,
+                    pr_number=pr_number,
+                    body=updated_body,
+                )
+                linked.append(pr_number)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to link generated issue #%s to PR #%s in %s/%s: %s",
+                    issue_number,
+                    pr_number,
+                    owner,
+                    repo,
+                    exc,
+                )
+
+        if linked:
+            try:
+                rendered = ", ".join(f"#{number}" for number in linked)
+                await self._github_tools.add_issue_comment(
+                    owner=owner,
+                    repo=repo,
+                    issue_number=issue_number,
+                    body=(
+                        "PipelineHealer linked this generated issue to active pull request(s): "
+                        f"{rendered}.\n\n"
+                        f"Issue URL: {issue_url}"
+                    ),
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Failed to comment on linked generated issue #%s in %s/%s: %s",
+                    issue_number,
+                    owner,
+                    repo,
+                    exc,
+                )
+
+        return linked
+
+    async def _close_superseded_generated_issue(
+        self,
+        *,
+        owner: str,
+        repo: str,
+        issue_number: int,
+        pr_number: int,
+        pr_url: str,
+    ) -> None:
+        """Close a stale generated review issue once a concrete PR supersedes it."""
+        await self._github_tools.add_issue_comment(
+            owner=owner,
+            repo=repo,
+            issue_number=issue_number,
+            body=(
+                "Superseded by a concrete remediation PR.\n\n"
+                f"- PR: #{pr_number} ({pr_url})\n"
+                "- Reason: PipelineHealer opened a PR-based fix for the same workflow run."
+            ),
+        )
+        await self._github_tools.update_issue(
+            owner=owner,
+            repo=repo,
+            issue_number=issue_number,
+            state="closed",
+            state_reason="completed",
+        )
 
     async def _create_pull_request(
         self,
@@ -778,6 +953,36 @@ class RemediationAgent:
             pr_url = pr_result.get("html_url", "")
             logger.info(f"Created PR: {pr_url}")
 
+            superseded_issues = await self._find_superseded_review_issues(
+                owner=owner,
+                repo=repo,
+                workflow_run_id=workflow_run_id,
+            )
+            closed_superseded_issue_numbers: list[int] = []
+            for issue in superseded_issues:
+                issue_number = issue.get("number")
+                if not isinstance(issue_number, int):
+                    continue
+                if tracking_issue_number is not None and issue_number == tracking_issue_number:
+                    continue
+                try:
+                    await self._close_superseded_generated_issue(
+                        owner=owner,
+                        repo=repo,
+                        issue_number=issue_number,
+                        pr_number=int(pr_result.get("number") or 0),
+                        pr_url=pr_url,
+                    )
+                    closed_superseded_issue_numbers.append(issue_number)
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to close superseded generated issue #%s in %s/%s: %s",
+                        issue_number,
+                        owner,
+                        repo,
+                        exc,
+                    )
+
             return RemediationResult(
                 success=True,
                 action_taken=RemediationAction.CREATE_PR,
@@ -790,6 +995,7 @@ class RemediationAgent:
                     "reused_existing_pr": False,
                     "remediation_fingerprint": remediation_fp,
                     "patch_drafting_trace": patch_drafting_trace,
+                    "closed_superseded_issue_numbers": closed_superseded_issue_numbers,
                 },
             )
 
@@ -1270,6 +1476,7 @@ class RemediationAgent:
         owner: str,
         repo: str,
         workflow_run_id: int,
+        repository_info: dict[str, Any] | None = None,
     ) -> RemediationResult:
         """Create an issue with the diagnosis details.
 
@@ -1283,8 +1490,55 @@ class RemediationAgent:
             Result of the issue creation
         """
         try:
+            remediation_fp = self._fingerprint_for_plan(plan, workflow_run_id)
+            fp_marker = self._fingerprint_marker(remediation_fp)
+            existing_issue = await self._find_existing_generated_issue(
+                owner=owner,
+                repo=repo,
+                marker=fp_marker,
+                workflow_run_id=workflow_run_id,
+                kind="review",
+                title=plan.issue_title or "[PipelineHealer] CI Failure Analysis",
+            )
+            pull_request_numbers = [
+                int(number)
+                for number in ((repository_info or {}).get("pull_request_numbers") or [])
+                if isinstance(number, int)
+            ]
+            if existing_issue is not None:
+                issue_number = existing_issue.get("number")
+                issue_url = str(existing_issue.get("html_url", "") or "")
+                reused_issue_linked_pr_numbers: list[int] = []
+                if isinstance(issue_number, int) and pull_request_numbers:
+                    reused_issue_linked_pr_numbers = await self._link_generated_issue_to_pull_requests(
+                        owner=owner,
+                        repo=repo,
+                        issue_number=issue_number,
+                        issue_url=issue_url,
+                        pull_request_numbers=pull_request_numbers,
+                    )
+                return RemediationResult(
+                    success=True,
+                    action_taken=RemediationAction.CREATE_ISSUE,
+                    issue_url=issue_url,
+                    details={
+                        "issue_number": issue_number,
+                        "reused_existing_issue": True,
+                        "remediation_fingerprint": remediation_fp,
+                        "linked_pull_request_numbers": reused_issue_linked_pr_numbers,
+                    },
+                )
+
             # Add workflow run link to the issue body
-            body = plan.issue_body or ""
+            body = (plan.issue_body or "").rstrip()
+            body += (
+                "\n\n"
+                + self._generated_issue_kind_marker("review")
+                + "\n"
+                + self._workflow_run_marker(workflow_run_id)
+                + "\n"
+                + fp_marker
+            )
             body += f"\n\n**Workflow Run:** https://github.com/{owner}/{repo}/actions/runs/{workflow_run_id}"
             includes_proposed_fix = "### Proposed Fix (For Review Only)" in body
             reason_code_match = re.search(r"Reason Code:\s*([A-Z_]+)", body)
@@ -1302,16 +1556,29 @@ class RemediationAgent:
 
             issue_url = issue_result.get("html_url", "")
             logger.info(f"Created issue: {issue_url}")
+            issue_number = issue_result.get("number")
+            linked_pr_numbers: list[int] = []
+            if isinstance(issue_number, int) and pull_request_numbers:
+                linked_pr_numbers = await self._link_generated_issue_to_pull_requests(
+                    owner=owner,
+                    repo=repo,
+                    issue_number=issue_number,
+                    issue_url=issue_url,
+                    pull_request_numbers=pull_request_numbers,
+                )
 
             return RemediationResult(
                 success=True,
                 action_taken=RemediationAction.CREATE_ISSUE,
                 issue_url=issue_url,
                 details={
-                    "issue_number": issue_result.get("number"),
+                    "issue_number": issue_number,
                     "includes_proposed_fix": includes_proposed_fix,
                     "not_auto_reason_code": not_auto_reason_code,
                     "not_auto_reason_detail": not_auto_reason_detail,
+                    "remediation_fingerprint": remediation_fp,
+                    "linked_pull_request_numbers": linked_pr_numbers,
+                    "reused_existing_issue": False,
                 },
             )
 

--- a/backend/src/tools/github_tools.py
+++ b/backend/src/tools/github_tools.py
@@ -525,6 +525,41 @@ class GitHubTools:
         )
         return cast(dict[str, Any], response.json())
 
+    async def get_pull_request(
+        self,
+        owner: str,
+        repo: str,
+        pr_number: int,
+    ) -> dict[str, Any]:
+        """Fetch one pull request."""
+        response = await self._request(
+            "GET",
+            f"/repos/{owner}/{repo}/pulls/{pr_number}",
+        )
+        return cast(dict[str, Any], response.json())
+
+    async def update_pull_request(
+        self,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        *,
+        title: str | None = None,
+        body: str | None = None,
+    ) -> dict[str, Any]:
+        """Update mutable pull request fields."""
+        payload: dict[str, Any] = {}
+        if title is not None:
+            payload["title"] = title
+        if body is not None:
+            payload["body"] = body
+        response = await self._request(
+            "PATCH",
+            f"/repos/{owner}/{repo}/pulls/{pr_number}",
+            json=payload,
+        )
+        return cast(dict[str, Any], response.json())
+
     async def get_pull_request_files(
         self,
         owner: str,
@@ -737,6 +772,34 @@ class GitHubTools:
         items = cast(list[dict[str, Any]], response.json())
         return [item for item in items if "pull_request" not in item]
 
+    async def update_issue(
+        self,
+        owner: str,
+        repo: str,
+        issue_number: int,
+        *,
+        title: str | None = None,
+        body: str | None = None,
+        state: str | None = None,
+        state_reason: str | None = None,
+    ) -> dict[str, Any]:
+        """Update mutable issue fields including open/closed state."""
+        payload: dict[str, Any] = {}
+        if title is not None:
+            payload["title"] = title
+        if body is not None:
+            payload["body"] = body
+        if state is not None:
+            payload["state"] = state
+        if state_reason is not None:
+            payload["state_reason"] = state_reason
+        response = await self._request(
+            "PATCH",
+            f"/repos/{owner}/{repo}/issues/{issue_number}",
+            json=payload,
+        )
+        return cast(dict[str, Any], response.json())
+
     # =========================================================================
     # Workflow Re-run Tools
     # =========================================================================
@@ -808,12 +871,15 @@ def create_github_tool_functions(github_tools: GitHubTools) -> dict[str, Any]:
         "create_branch": github_tools.create_branch,
         "create_or_update_file": github_tools.create_or_update_file,
         "create_pull_request": github_tools.create_pull_request,
+        "get_pull_request": github_tools.get_pull_request,
+        "update_pull_request": github_tools.update_pull_request,
         "list_pull_requests": github_tools.list_pull_requests,
         "get_pull_request_files": github_tools.get_pull_request_files,
         "create_issue": github_tools.create_issue,
         "add_issue_comment": github_tools.add_issue_comment,
         "list_issue_comments": github_tools.list_issue_comments,
         "list_issues": github_tools.list_issues,
+        "update_issue": github_tools.update_issue,
         "search_issues": github_tools.search_issues,
         "rerun_workflow": github_tools.rerun_workflow,
         "rerun_failed_jobs": github_tools.rerun_failed_jobs,

--- a/backend/tests/test_phase1_correctness.py
+++ b/backend/tests/test_phase1_correctness.py
@@ -62,6 +62,10 @@ class FakeGitHubTools:
     def __init__(self) -> None:
         self.rerun_calls: list[tuple[str, str, int]] = []
         self.issue_calls: list[dict[str, str]] = []
+        self.issue_comment_calls: list[dict[str, str | int]] = []
+        self.issue_update_calls: list[dict[str, str | int]] = []
+        self.pull_request_update_calls: list[dict[str, str | int]] = []
+        self.pull_requests_by_number: dict[int, dict[str, object]] = {}
 
     async def get_file_contents(self, owner: str, repo: str, path: str, ref: str | None = None):
         raise NotImplementedError
@@ -119,6 +123,39 @@ class FakeGitHubTools:
     async def get_pull_request_files(self, owner: str, repo: str, pr_number: int, per_page: int = 100):
         _ = owner, repo, pr_number, per_page
         return []
+
+    async def get_pull_request(self, owner: str, repo: str, pr_number: int):
+        _ = owner, repo
+        return self.pull_requests_by_number.get(
+            pr_number,
+            {
+                "number": pr_number,
+                "body": "",
+                "html_url": f"https://github.com/{owner}/{repo}/pull/{pr_number}",
+            },
+        )
+
+    async def update_pull_request(
+        self,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        *,
+        title: str | None = None,
+        body: str | None = None,
+    ):
+        _ = owner, repo, title
+        current = dict(await self.get_pull_request(owner, repo, pr_number))
+        if body is not None:
+            current["body"] = body
+        self.pull_requests_by_number[pr_number] = current
+        self.pull_request_update_calls.append(
+            {
+                "pr_number": pr_number,
+                "body": str(body or ""),
+            }
+        )
+        return current
 
     async def list_issues(
         self,
@@ -178,6 +215,38 @@ class FakeGitHubTools:
             }
         )
         return {"number": 1, "html_url": f"https://github.com/{owner}/{repo}/issues/1"}
+
+    async def add_issue_comment(self, owner: str, repo: str, issue_number: int, body: str):
+        self.issue_comment_calls.append(
+            {
+                "owner": owner,
+                "repo": repo,
+                "issue_number": issue_number,
+                "body": body,
+            }
+        )
+        return {"id": len(self.issue_comment_calls), "body": body}
+
+    async def update_issue(
+        self,
+        owner: str,
+        repo: str,
+        issue_number: int,
+        *,
+        title: str | None = None,
+        body: str | None = None,
+        state: str | None = None,
+        state_reason: str | None = None,
+    ):
+        _ = owner, repo, title, body
+        self.issue_update_calls.append(
+            {
+                "issue_number": issue_number,
+                "state": str(state or ""),
+                "state_reason": str(state_reason or ""),
+            }
+        )
+        return {"number": issue_number, "state": state, "state_reason": state_reason}
 
 
 class FakeGitHubToolsWithFiles(FakeGitHubTools):
@@ -323,6 +392,75 @@ class FakeGitHubToolsCapturePR(FakeGitHubToolsWithFiles):
             }
         )
         return {"number": 321, "html_url": f"https://github.com/{owner}/{repo}/pull/321"}
+
+
+class FakeGitHubToolsExistingGeneratedIssue(FakeGitHubTools):
+    def __init__(self) -> None:
+        super().__init__()
+        self._issues = [
+            {
+                "number": 9,
+                "html_url": "https://github.com/octo/demo/issues/9",
+                "title": "[PipelineHealer] Review required: lint",
+                "body": (
+                    "existing body\n\n"
+                    "<!-- pipelinehealer:generated-issue:review -->\n"
+                    "<!-- pipelinehealer:workflow-run:321 -->\n"
+                    "<!-- pipelinehealer:fingerprint:fixedfp123456789 -->"
+                ),
+            }
+        ]
+        self.pull_requests_by_number[77] = {
+            "number": 77,
+            "body": "Human fix PR body",
+            "html_url": "https://github.com/octo/demo/pull/77",
+        }
+
+    async def list_issues(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        state: str = "all",
+        labels: str | None = None,
+        sort: str = "updated",
+        direction: str = "desc",
+        per_page: int = 30,
+    ):
+        _ = owner, repo, state, labels, sort, direction, per_page
+        return list(self._issues)
+
+
+class FakeGitHubToolsSupersededReviewIssue(FakeGitHubToolsWithFiles):
+    def __init__(self) -> None:
+        super().__init__(files={"README.md": "hello\n"})
+        self._issues = [
+            {
+                "number": 41,
+                "html_url": "https://github.com/octo/demo/issues/41",
+                "title": "[PipelineHealer] Review required: dependency",
+                "body": (
+                    "review-only issue\n\n"
+                    "<!-- pipelinehealer:generated-issue:review -->\n"
+                    "<!-- pipelinehealer:workflow-run:555 -->\n"
+                    "<!-- pipelinehealer:fingerprint:reviewfp555 -->"
+                ),
+            }
+        ]
+
+    async def list_issues(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        state: str = "all",
+        labels: str | None = None,
+        sort: str = "updated",
+        direction: str = "desc",
+        per_page: int = 30,
+    ):
+        _ = owner, repo, state, labels, sort, direction, per_page
+        return list(self._issues)
 
 
 def _make_event() -> WorkflowRunEvent:
@@ -1151,6 +1289,80 @@ async def test_create_issue_when_issues_disabled_returns_skip() -> None:
 
 
 @pytest.mark.asyncio
+async def test_create_issue_links_active_pull_request_for_auto_close(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gh = FakeGitHubTools()
+    gh.pull_requests_by_number[22] = {
+        "number": 22,
+        "body": "Human fix PR body",
+        "html_url": "https://github.com/octo/demo/pull/22",
+    }
+    agent = RemediationAgent(github_tools=gh)
+    monkeypatch.setattr(agent, "_fingerprint_for_plan", lambda plan, workflow_run_id: "issuefp1234567890")
+    plan = RemediationPlan(
+        action=RemediationAction.CREATE_ISSUE,
+        description="Escalate for manual fix",
+        issue_title="[PipelineHealer] Review required: lint",
+        issue_body="Root cause summary\n\n### Proposed Fix (For Review Only)",
+    )
+
+    result = await agent._create_issue(
+        plan,
+        owner="octo",
+        repo="demo",
+        workflow_run_id=123,
+        repository_info={"pull_request_numbers": [22]},
+    )
+
+    assert result.success is True
+    assert result.action_taken == RemediationAction.CREATE_ISSUE
+    assert result.issue_url == "https://github.com/octo/demo/issues/1"
+    assert result.details.get("linked_pull_request_numbers") == [22]
+    assert result.details.get("reused_existing_issue") is False
+    assert gh.issue_calls
+    assert "<!-- pipelinehealer:generated-issue:review -->" in gh.issue_calls[0]["body"]
+    assert "<!-- pipelinehealer:workflow-run:123 -->" in gh.issue_calls[0]["body"]
+    assert "<!-- pipelinehealer:fingerprint:issuefp1234567890 -->" in gh.issue_calls[0]["body"]
+    assert gh.pull_request_update_calls
+    assert "Closes #1" in str(gh.pull_request_update_calls[0]["body"])
+    assert gh.issue_comment_calls
+    assert "#22" in str(gh.issue_comment_calls[0]["body"])
+
+
+@pytest.mark.asyncio
+async def test_create_issue_reuses_existing_generated_issue_and_links_pr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gh = FakeGitHubToolsExistingGeneratedIssue()
+    agent = RemediationAgent(github_tools=gh)
+    monkeypatch.setattr(agent, "_fingerprint_for_plan", lambda plan, workflow_run_id: "fixedfp123456789")
+    plan = RemediationPlan(
+        action=RemediationAction.CREATE_ISSUE,
+        description="Escalate for manual fix",
+        issue_title="[PipelineHealer] Review required: lint",
+        issue_body="Root cause summary",
+    )
+
+    result = await agent._create_issue(
+        plan,
+        owner="octo",
+        repo="demo",
+        workflow_run_id=321,
+        repository_info={"pull_request_numbers": [77]},
+    )
+
+    assert result.success is True
+    assert result.issue_url == "https://github.com/octo/demo/issues/9"
+    assert result.details.get("issue_number") == 9
+    assert result.details.get("reused_existing_issue") is True
+    assert result.details.get("linked_pull_request_numbers") == [77]
+    assert gh.issue_calls == []
+    assert gh.pull_request_update_calls
+    assert "Closes #9" in str(gh.pull_request_update_calls[0]["body"])
+
+
+@pytest.mark.asyncio
 async def test_create_pr_when_repo_read_only_returns_skip() -> None:
     gh = FakeGitHubToolsReadOnlyRepo()
     agent = RemediationAgent(github_tools=gh)
@@ -1203,6 +1415,35 @@ async def test_create_pr_reuses_existing_open_pr_on_ref_collision() -> None:
     assert result.pr_url == "https://github.com/octo/demo/pull/88"
     assert result.details.get("reused_existing_pr") is True
     assert gh.created_pr is False
+
+
+@pytest.mark.asyncio
+async def test_create_pr_closes_superseded_review_issue() -> None:
+    gh = FakeGitHubToolsSupersededReviewIssue()
+    agent = RemediationAgent(github_tools=gh)
+    plan = RemediationPlan(
+        action=RemediationAction.CREATE_PR,
+        description="Install missing dependency",
+        branch_name="fix/dependency",
+        pr_title="[PipelineHealer] dependency fix",
+        pr_body="body",
+        file_changes=[{"file": "README.md", "content": "updated"}],
+    )
+
+    result = await agent._create_pull_request(
+        plan=plan,
+        owner="octo",
+        repo="demo",
+        base_branch="main",
+        workflow_run_id=555,
+    )
+
+    assert result.success is True
+    assert result.action_taken == RemediationAction.CREATE_PR
+    assert result.details.get("closed_superseded_issue_numbers") == [41]
+    assert gh.issue_comment_calls
+    assert "Superseded by a concrete remediation PR." in str(gh.issue_comment_calls[0]["body"])
+    assert gh.issue_update_calls == [{"issue_number": 41, "state": "closed", "state_reason": "completed"}]
 
 
 @pytest.mark.asyncio

--- a/docs/DIAGNOSIS_REMEDIATION_ARCHITECTURE_PLAN.md
+++ b/docs/DIAGNOSIS_REMEDIATION_ARCHITECTURE_PLAN.md
@@ -416,7 +416,7 @@ Use this checklist for the `v0.6.0` workstream.
 - [x] rollout gates defined for schema changes and model-role changes
 - [x] live incident regressions from generated issues are added to the eval corpus before release closeout
 - [x] generated issue quality avoids generic empty-count titles and bodies for static-analysis/import-blocking failures
-- [ ] generated review issues can be linked to active human fix PRs with auto-close semantics and stale-issue cleanup guidance
+- [x] generated review issues can be linked to active human fix PRs with auto-close semantics and stale-issue cleanup guidance
 
 ## Suggested PR Slices
 

--- a/docs/FUTURE_PLAN.md
+++ b/docs/FUTURE_PLAN.md
@@ -531,7 +531,7 @@ These items are researched and tracked; some have scoped phased rollout while ot
 | `BL-055` | Frontend coherence patch: explicit 404 routing for public paths plus semantic badge-theme cleanup after live `v0.5.0` validation ([#92](https://github.com/Canepro/pipelinehealer/issues/92)) | `v0.5.1` | patch | Medium | In Progress |
 | `BL-056` | Incident-derived eval expansion for diagnosis/remediation hardening: capture live regressions like stale dependency suggestions, zero-count failure issues, and static-analysis/bounded-draft failures as first-class fixtures | `v0.6.0` | minor | High | In Progress |
 | `BL-057` | Review-only issue quality hardening: remove generic titles/body fallbacks (`unknown violations`, `0 test(s) failed`) by using failing-step/failing-command/static-analysis context when structured evidence is partial | `v0.6.0` | minor | High | In Progress |
-| `BL-058` | PipelineHealer-generated issue lifecycle hygiene: validate, link, and auto-close active review issues from human fix PRs, and close stale/superseded generated issues with audit comments | `v0.6.0` | patch/minor | Medium | Planned |
+| `BL-058` | PipelineHealer-generated issue lifecycle hygiene: validate, link, and auto-close active review issues from human fix PRs, and close stale/superseded generated issues with audit comments | `v0.6.0` | patch/minor | Medium | In Progress |
 
 ## Definition of Done (Per Version)
 


### PR DESCRIPTION
## Summary
- add deterministic markers and reuse for PipelineHealer-generated review issues instead of reopening duplicates for the same workflow run
- link generated review issues to active PR-backed runs by appending a Closes reference to the PR body and recording the linkage on the issue
- close stale generated review issues with an audit comment when a concrete remediation PR supersedes them

## Verification
- pytest -q backend/tests/test_phase1_correctness.py
- pytest -q backend/tests/test_diagnosis.py backend/tests/test_phase1_5_demo_mode.py backend/tests/test_eval_harness.py backend/tests/test_phase1_correctness.py
- mypy src
- python3 -m py_compile backend/src/agents/remediation.py backend/src/tools/github_tools.py

## Notes
- this completes the tracked BL-058 lifecycle-hygiene slice for v0.6.0