### PR TITLE
Harden diagnosis schema validation

### DIFF
--- a/backend/src/agents/diagnosis.py
+++ b/backend/src/agents/diagnosis.py
@@ -23,6 +23,63 @@ from .base import create_cloud_agent, get_agent_prompt
 logger = logging.getLogger(__name__)
 
 
+LLM_REQUIRED_TOP_LEVEL_FIELDS = (
+    "failure_type",
+    "confidence",
+    "root_cause",
+    "affected_files",
+    "is_auto_fixable",
+    "suggested_fix",
+    "error_details",
+)
+
+LLM_ERROR_DETAILS_SCHEMA: dict[FailureType, dict[str, Any]] = {
+    FailureType.DEPENDENCY: {
+        "package_name": "",
+        "package_manager": "",
+        "manifest_file": "",
+        "current_version": "",
+        "required_version": "",
+        "resolution_kind": "",
+    },
+    FailureType.LINT: {
+        "linter": "",
+        "missing_file": "",
+        "config_file": "",
+        "autofix_command": "",
+        "violations": [],
+        "rule_ids": [],
+    },
+    FailureType.TEST: {
+        "test_framework": "",
+        "failed_tests": [],
+        "test_errors": {},
+        "is_flaky": False,
+        "failure_scope": "",
+        "suspected_files": [],
+    },
+    FailureType.TIMEOUT: {
+        "timed_out_job": "",
+        "timed_out_step": "",
+        "timeout_minutes": 0,
+        "suggested_timeout": 0,
+        "resource_signal": "",
+        "likely_fix_kind": "",
+    },
+    FailureType.BUILD_CONFIG: {
+        "config_file": "",
+        "config_error": "",
+        "missing_env_vars": [],
+        "workflow_permissions_fix": False,
+        "permissions": {},
+        "misconfiguration_kind": "",
+    },
+    FailureType.UNKNOWN: {
+        "additional": "",
+    },
+}
+
+
 class DiagnosisAgent:
     """Agent for diagnosing the root cause of CI/CD failures.
 
@@ -63,6 +120,21 @@ class DiagnosisAgent:
         """Refresh mutable settings and rebuild cloud client on next call."""
         self._settings = get_settings()
         self._agent = None
+
+    def _build_llm_error_details_schema_text(self) -> str:
+        """Render the failure-type-specific error_details contract for the diagnosis prompt."""
+        schema_lines = []
+        for failure_type in (
+            FailureType.DEPENDENCY,
+            FailureType.LINT,
+            FailureType.TEST,
+            FailureType.TIMEOUT,
+            FailureType.BUILD_CONFIG,
+            FailureType.UNKNOWN,
+        ):
+            template = json.dumps(LLM_ERROR_DETAILS_SCHEMA[failure_type], ensure_ascii=True)
+            schema_lines.append(f'- `{failure_type.value}`: {template}')
+        return "\n".join(schema_lines)
 
     async def diagnose(
         self,
@@ -139,6 +211,7 @@ class DiagnosisAgent:
             similar_issues=similar_issues,
         )
         external_summary = self._prepare_external_diagnostics_summary(external_diagnostics)
+        error_details_schema_text = self._build_llm_error_details_schema_text()
 
         prompt = f"""Analyze the following CI/CD failure and provide a diagnosis.
 
@@ -165,6 +238,13 @@ Provide your diagnosis in the following JSON format:
         "missing_env_vars": ["for build config failures when known"]
     }}
 }}
+
+Return exactly one JSON object with no markdown fences and no extra commentary.
+For the chosen `failure_type`, `error_details` must include every key from the matching schema below.
+Use empty strings, empty arrays/objects, `false`, or `0` when a field is unknown, but do not omit keys.
+
+Failure-type-specific `error_details` schemas:
+{error_details_schema_text}
 
 Be specific about:
 1. The exact failure type category
@@ -1437,6 +1517,56 @@ Be specific about:
         candidates.sort(key=len, reverse=True)
         return candidates
 
+    @staticmethod
+    def _required_llm_error_details_keys(failure_type: FailureType) -> tuple[str, ...]:
+        template = LLM_ERROR_DETAILS_SCHEMA.get(failure_type, LLM_ERROR_DETAILS_SCHEMA[FailureType.UNKNOWN])
+        return tuple(template.keys())
+
+    def _validate_llm_diagnosis_payload(
+        self,
+        data: dict[str, Any],
+        failure_type: FailureType,
+    ) -> tuple[bool, str]:
+        """Validate that an LLM diagnosis payload matches the structured contract."""
+        missing_top_level = [field for field in LLM_REQUIRED_TOP_LEVEL_FIELDS if field not in data]
+        if missing_top_level:
+            return False, f"missing top-level field(s): {', '.join(missing_top_level)}"
+
+        confidence_raw = data.get("confidence")
+        if confidence_raw is None:
+            return False, "confidence is missing"
+        try:
+            confidence = float(confidence_raw)
+        except (TypeError, ValueError):
+            return False, "confidence is not numeric"
+        if not 0.0 <= confidence <= 1.0:
+            return False, "confidence is outside 0.0-1.0"
+
+        if not isinstance(data.get("root_cause"), str) or not str(data.get("root_cause")).strip():
+            return False, "root_cause must be a non-empty string"
+        if not isinstance(data.get("suggested_fix"), str):
+            return False, "suggested_fix must be a string"
+        if not isinstance(data.get("is_auto_fixable"), bool):
+            return False, "is_auto_fixable must be a boolean"
+
+        affected_files = data.get("affected_files")
+        if not isinstance(affected_files, list) or any(not isinstance(item, str) for item in affected_files):
+            return False, "affected_files must be a list of strings"
+
+        error_details = data.get("error_details")
+        if not isinstance(error_details, dict):
+            return False, "error_details must be an object"
+
+        missing_error_detail_keys = [
+            key
+            for key in self._required_llm_error_details_keys(failure_type)
+            if key not in error_details
+        ]
+        if missing_error_detail_keys:
+            return False, f"missing error_details field(s): {', '.join(missing_error_detail_keys)}"
+
+        return True, ""
+
     def _parse_diagnosis_response(
         self,
         response_text: str,
@@ -1475,6 +1605,14 @@ Be specific about:
 
             failure_type_str = str(data.get("failure_type", "unknown")).lower()
             failure_type = failure_type_map.get(failure_type_str, FailureType.UNKNOWN)
+            is_valid, reason = self._validate_llm_diagnosis_payload(data, failure_type)
+            if not is_valid:
+                logger.warning(
+                    "Rejected LLM diagnosis payload for %s: %s",
+                    failure_type.value,
+                    reason,
+                )
+                continue
 
             return Diagnosis(
                 failure_type=failure_type,
@@ -1503,6 +1641,7 @@ Be specific about:
             is_auto_fixable=False,
             diagnosis_source=DiagnosisSource.LLM,
         )
+
     @staticmethod
     def _with_source(diagnosis: Diagnosis, source: DiagnosisSource) -> Diagnosis:
         """Ensure diagnosis source is set for observability/UI trust surface."""

--- a/backend/src/tools/github_tools.py
+++ b/backend/src/tools/github_tools.py
@@ -553,6 +553,8 @@ class GitHubTools:
             payload["title"] = title
         if body is not None:
             payload["body"] = body
+        if not payload:
+            raise ValueError("update_pull_request requires at least one mutable field")
         response = await self._request(
             "PATCH",
             f"/repos/{owner}/{repo}/pulls/{pr_number}",
@@ -793,6 +795,8 @@ class GitHubTools:
             payload["state"] = state
         if state_reason is not None:
             payload["state_reason"] = state_reason
+        if not payload:
+            raise ValueError("update_issue requires at least one mutable field")
         response = await self._request(
             "PATCH",
             f"/repos/{owner}/{repo}/issues/{issue_number}",

--- a/backend/tests/test_diagnosis.py
+++ b/backend/tests/test_diagnosis.py
@@ -4,6 +4,7 @@ import pytest
 
 from src.agents.diagnosis import DiagnosisAgent
 from src.models import (
+    Diagnosis,
     DiagnosisSource,
     ExternalDiagnostic,
     ExternalDiagnosticStatus,
@@ -678,3 +679,75 @@ class TestPatternBasedDiagnosis:
         assert "hosted runner" in diagnosis.root_cause
         assert diagnosis.error_details.get("reason_code") == "github_runner_acquisition_failed"
         assert diagnosis.error_details.get("infrastructure_failure") is True
+
+    def test_parse_llm_diagnosis_rejects_missing_failure_specific_fields(self) -> None:
+        """Malformed LLM JSON should fall back when required typed fields are missing."""
+        fallback = Diagnosis(
+            failure_type=FailureType.TEST,
+            confidence=0.85,
+            root_cause="pytest test failed",
+            is_auto_fixable=False,
+            suggested_fix="Run pytest locally and fix the failure.",
+            error_details={
+                "test_framework": "pytest",
+                "failed_tests": ["tests/test_api.py::test_health"],
+                "test_errors": {"tests/test_api.py::test_health": "AssertionError"},
+                "is_flaky": False,
+                "failure_scope": "test_case",
+                "suspected_files": ["tests/test_api.py"],
+            },
+            diagnosis_source=DiagnosisSource.PATTERN,
+        )
+
+        diagnosis = self.agent._parse_diagnosis_response(
+            (
+                '{"failure_type":"test","confidence":0.82,"root_cause":"pytest failed",'
+                '"affected_files":["tests/test_api.py"],"is_auto_fixable":false,'
+                '"suggested_fix":"run pytest","error_details":{"test_framework":"pytest"}}'
+            ),
+            fallback,
+        )
+
+        assert diagnosis is fallback
+
+    def test_parse_llm_diagnosis_accepts_complete_failure_specific_schema(self) -> None:
+        """Well-formed LLM JSON with complete typed keys should be accepted."""
+        diagnosis = self.agent._parse_diagnosis_response(
+            (
+                '{"failure_type":"dependency","confidence":0.81,"root_cause":"missing Python module",'
+                '"affected_files":["pyproject.toml"],"is_auto_fixable":true,'
+                '"suggested_fix":"Add the dependency and reinstall.","error_details":{'
+                '"package_name":"requests","package_manager":"pip","manifest_file":"pyproject.toml",'
+                '"current_version":"","required_version":"","resolution_kind":"missing"}}'
+            ),
+            None,
+        )
+
+        assert diagnosis.failure_type == FailureType.DEPENDENCY
+        assert diagnosis.diagnosis_source == DiagnosisSource.LLM
+        assert diagnosis.error_details.get("package_name") == "requests"
+
+    def test_validate_llm_diagnosis_payload_accepts_complete_lint_schema(self) -> None:
+        """Structured lint payloads with the full typed key set should validate cleanly."""
+        valid, reason = self.agent._validate_llm_diagnosis_payload(
+            {
+                "failure_type": "lint",
+                "confidence": 0.7,
+                "root_cause": "lint failed",
+                "affected_files": ["eslint.config.js"],
+                "is_auto_fixable": False,
+                "suggested_fix": "Add the missing config.",
+                "error_details": {
+                    "linter": "eslint",
+                    "missing_file": "eslint.config.js",
+                    "config_file": "eslint.config.js",
+                    "autofix_command": "",
+                    "violations": [],
+                    "rule_ids": [],
+                },
+            },
+            FailureType.LINT,
+        )
+
+        assert valid is True
+        assert reason == ""

--- a/backend/tests/test_github_tools.py
+++ b/backend/tests/test_github_tools.py
@@ -96,3 +96,27 @@ async def test_get_recent_commits_passes_since_parameter() -> None:
     assert captured["url"] == "/repos/Canepro/pipelinehealer/commits"
     assert captured["kwargs"]["params"]["since"] == "2026-02-01T00:00:00Z"
     assert captured["kwargs"]["params"]["per_page"] == 7
+
+
+@pytest.mark.asyncio
+async def test_update_pull_request_rejects_empty_payload() -> None:
+    gh = GitHubTools(token="test-token")
+
+    with pytest.raises(ValueError, match="at least one mutable field"):
+        await gh.update_pull_request(
+            owner="Canepro",
+            repo="pipelinehealer",
+            pr_number=42,
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_issue_rejects_empty_payload() -> None:
+    gh = GitHubTools(token="test-token")
+
+    with pytest.raises(ValueError, match="at least one mutable field"):
+        await gh.update_issue(
+            owner="Canepro",
+            repo="pipelinehealer",
+            issue_number=42,
+        )

--- a/backend/tests/test_llm_provider_contracts.py
+++ b/backend/tests/test_llm_provider_contracts.py
@@ -18,14 +18,18 @@ from src.models import DiagnosisSource, FailureType, LogAnalysis
             "azure_openai",
             '{"failure_type":"build_config","confidence":0.81,"root_cause":"missing env var",'
             '"affected_files":[".github/workflows/ci.yml"],"is_auto_fixable":true,'
-            '"suggested_fix":"add required env var","error_details":{"source":"azure"}}',
+            '"suggested_fix":"add required env var","error_details":{"config_file":".github/workflows/ci.yml",'
+            '"config_error":"missing env var","missing_env_vars":["API_TOKEN"],'
+            '"workflow_permissions_fix":false,"permissions":{},"misconfiguration_kind":"env_var"}}',
         ),
         (
             "openai_compatible",
             "Here is the diagnosis:\n```json\n"
             '{"failure_type":"build_config","confidence":0.81,"root_cause":"missing env var",'
             '"affected_files":[".github/workflows/ci.yml"],"is_auto_fixable":true,'
-            '"suggested_fix":"add required env var","error_details":{"source":"openai_compatible"}}'
+            '"suggested_fix":"add required env var","error_details":{"config_file":".github/workflows/ci.yml",'
+            '"config_error":"missing env var","missing_env_vars":["API_TOKEN"],'
+            '"workflow_permissions_fix":false,"permissions":{},"misconfiguration_kind":"env_var"}}'
             "\n```",
         ),
     ],

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # PipelineHealer API Reference
 
-<!-- LAST_VERIFIED: d82efee -->
+<!-- LAST_VERIFIED: 803e871 -->
 
 This document describes the PipelineHealer backend REST API, authentication model, request/response contracts, and best practices.
 
@@ -1250,6 +1250,8 @@ When `diagnosis_source=pattern`, `error_details` may include classification tran
 - `classification_pattern`: internal pattern signature used for matching
 
 Pattern and LLM diagnoses may also include failure-type-specific structured fields in `error_details`.
+
+For LLM-sourced diagnoses, PipelineHealer now expects the full failure-type-specific key set to be present in `error_details` for the chosen `failure_type`. If the model returns malformed JSON or omits required typed keys, the LLM payload is rejected and PipelineHealer falls back to deterministic diagnosis data when available.
 
 Common examples:
 - `dependency`: `package_name`, `package_manager`, `manifest_file`, `required_version`, `resolution_kind`

--- a/docs/DIAGNOSIS_REMEDIATION_ARCHITECTURE_PLAN.md
+++ b/docs/DIAGNOSIS_REMEDIATION_ARCHITECTURE_PLAN.md
@@ -1,4 +1,4 @@
-<!-- LAST_VERIFIED: aec8f84 -->
+<!-- LAST_VERIFIED: 803e871 -->
 
 # Diagnosis and Remediation Architecture Plan
 
@@ -398,8 +398,8 @@ Use this checklist for the `v0.6.0` workstream.
 
 ### LLM layer
 
-- [ ] diagnosis prompt updated to require failure-type-specific structured JSON
-- [ ] parser rejects incomplete or malformed structured payloads cleanly
+- [x] diagnosis prompt updated to require failure-type-specific structured JSON
+- [x] parser rejects incomplete or malformed structured payloads cleanly
 - [x] role mapping documented for `analysis`, `diagnosis_refinement`, `patch_drafting`, and `operator_summary`
 
 ### Remediation layer

--- a/docs/LLM_AND_AGENT_RUNTIME.md
+++ b/docs/LLM_AND_AGENT_RUNTIME.md
@@ -1,6 +1,6 @@
 # LLM and Agent Runtime
 
-<!-- LAST_VERIFIED: aec8f84 -->
+<!-- LAST_VERIFIED: 803e871 -->
 
 This document is the operator-facing contract for how PipelineHealer uses LLMs and agents at runtime.
 
@@ -37,6 +37,24 @@ Internal role note:
 Current limitation:
 - you cannot use Azure for analysis and `openai_compatible` for diagnosis/remediation in the same run
 - provider selection is global for the runtime, not per task
+
+## Diagnosis Contract Enforcement
+
+Diagnosis is now schema-gated, not prose-gated.
+
+Current runtime rule:
+- the diagnosis model must return exactly one JSON object
+- top-level diagnosis fields must all be present
+- `error_details` must include the full typed key set for the chosen `failure_type`
+- unknown values should be represented with empty strings, empty arrays/objects, `false`, or `0`, not omitted fields
+
+Fallback behavior:
+- malformed JSON is rejected
+- incomplete typed payloads are rejected
+- when rejection happens, PipelineHealer falls back to deterministic diagnosis when available instead of trusting partial LLM prose
+
+Operator implication:
+- a model that can answer loosely in natural language but cannot satisfy the structured diagnosis contract is not full-capability for diagnosis
 
 ## Readiness Levels
 


### PR DESCRIPTION
## Summary
- address the merged #122 review findings by guarding empty update payloads in GitHub PR/issue patch helpers
- require diagnosis LLM responses to return complete failure-type-specific JSON key sets instead of partial prose-like payloads
- reject malformed or incomplete LLM diagnosis payloads and fall back to deterministic diagnosis when available

## Verification
- pytest -q backend/tests/test_github_tools.py backend/tests/test_diagnosis.py backend/tests/test_llm_provider_contracts.py backend/tests/test_phase1_correctness.py
- mypy src
- python3 -m py_compile backend/src/agents/diagnosis.py backend/src/tools/github_tools.py backend/src/agents/remediation.py

## Notes
- this continues the tracked v0.6.0 diagnosis/remediation hardening plan by completing the LLM-layer schema enforcement items