### PR TITLE
Add diagnosis rejection telemetry

### DIFF
--- a/backend/src/agents/diagnosis.py
+++ b/backend/src/agents/diagnosis.py
@@ -229,14 +229,7 @@ Provide your diagnosis in the following JSON format:
     "affected_files": ["list", "of", "files"],
     "is_auto_fixable": true/false,
     "suggested_fix": "High-level suggestion",
-    "error_details": {{
-        "additional": "context-specific details",
-        "package_name": "for dependency failures when known",
-        "missing_file": "for lint/config failures when known",
-        "failed_tests": ["for test failures when known"],
-        "timeout_minutes": 0,
-        "missing_env_vars": ["for build config failures when known"]
-    }}
+    "error_details": {{ "see failure-type-specific schema below" }}
 }}
 
 Return exactly one JSON object with no markdown fences and no extra commentary.
@@ -1567,6 +1560,20 @@ Be specific about:
 
         return True, ""
 
+    @staticmethod
+    def _record_llm_payload_rejection(
+        diagnosis: Diagnosis,
+        *,
+        reason: str,
+        candidate_count: int,
+    ) -> Diagnosis:
+        """Annotate a fallback diagnosis with LLM payload rejection context."""
+        details = dict(diagnosis.error_details or {})
+        details["llm_payload_rejected"] = True
+        details["llm_payload_rejection_reason"] = reason
+        details["llm_payload_candidate_count"] = candidate_count
+        return diagnosis.model_copy(update={"error_details": details})
+
     def _parse_diagnosis_response(
         self,
         response_text: str,
@@ -1592,8 +1599,10 @@ Be specific about:
         # Strip markdown code fences that some LLMs wrap around JSON.
         cleaned = re.sub(r"```(?:json)?\s*", "", response_text)
         cleaned = re.sub(r"```\s*$", "", cleaned, flags=re.MULTILINE)
+        candidates = self._extract_json_candidates(cleaned)
+        rejection_reasons: list[str] = []
 
-        for candidate in self._extract_json_candidates(cleaned):
+        for candidate in candidates:
             try:
                 data = json.loads(candidate)
             except (json.JSONDecodeError, ValueError):
@@ -1612,6 +1621,7 @@ Be specific about:
                     failure_type.value,
                     reason,
                 )
+                rejection_reasons.append(f"{failure_type.value}: {reason}")
                 continue
 
             return Diagnosis(
@@ -1629,17 +1639,30 @@ Be specific about:
             "Failed to extract valid diagnosis JSON from agent response (len=%d)",
             len(response_text),
         )
+        rejection_reason = (
+            rejection_reasons[0]
+            if rejection_reasons
+            else "No valid structured diagnosis JSON candidate was found"
+        )
 
         # Return fallback or create unknown diagnosis
         if fallback:
-            return fallback
+            return self._record_llm_payload_rejection(
+                fallback,
+                reason=rejection_reason,
+                candidate_count=len(candidates),
+            )
 
-        return Diagnosis(
+        return self._record_llm_payload_rejection(
+            Diagnosis(
             failure_type=FailureType.UNKNOWN,
             confidence=0.3,
             root_cause="Could not determine root cause",
             is_auto_fixable=False,
             diagnosis_source=DiagnosisSource.LLM,
+            ),
+            reason=rejection_reason,
+            candidate_count=len(candidates),
         )
 
     @staticmethod

--- a/backend/tests/test_diagnosis.py
+++ b/backend/tests/test_diagnosis.py
@@ -708,7 +708,13 @@ class TestPatternBasedDiagnosis:
             fallback,
         )
 
-        assert diagnosis is fallback
+        assert diagnosis.failure_type == fallback.failure_type
+        assert diagnosis.root_cause == fallback.root_cause
+        assert diagnosis.error_details.get("llm_payload_rejected") is True
+        assert "missing error_details field(s)" in str(
+            diagnosis.error_details.get("llm_payload_rejection_reason")
+        )
+        assert diagnosis.error_details.get("llm_payload_candidate_count") == 2
 
     def test_parse_llm_diagnosis_accepts_complete_failure_specific_schema(self) -> None:
         """Well-formed LLM JSON with complete typed keys should be accepted."""
@@ -751,3 +757,18 @@ class TestPatternBasedDiagnosis:
 
         assert valid is True
         assert reason == ""
+
+    def test_parse_llm_diagnosis_records_rejection_on_unknown_fallback(self) -> None:
+        """Unknown diagnoses should retain rejection telemetry when LLM payload parsing fails."""
+        diagnosis = self.agent._parse_diagnosis_response(
+            "not-json-at-all",
+            None,
+        )
+
+        assert diagnosis.failure_type == FailureType.UNKNOWN
+        assert diagnosis.diagnosis_source == DiagnosisSource.LLM
+        assert diagnosis.error_details.get("llm_payload_rejected") is True
+        assert diagnosis.error_details.get("llm_payload_rejection_reason") == (
+            "No valid structured diagnosis JSON candidate was found"
+        )
+        assert diagnosis.error_details.get("llm_payload_candidate_count") == 0

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # PipelineHealer API Reference
 
-<!-- LAST_VERIFIED: 803e871 -->
+<!-- LAST_VERIFIED: 1bee670 -->
 
 This document describes the PipelineHealer backend REST API, authentication model, request/response contracts, and best practices.
 
@@ -1251,7 +1251,7 @@ When `diagnosis_source=pattern`, `error_details` may include classification tran
 
 Pattern and LLM diagnoses may also include failure-type-specific structured fields in `error_details`.
 
-For LLM-sourced diagnoses, PipelineHealer now expects the full failure-type-specific key set to be present in `error_details` for the chosen `failure_type`. If the model returns malformed JSON or omits required typed keys, the LLM payload is rejected and PipelineHealer falls back to deterministic diagnosis data when available.
+For LLM-sourced diagnoses, PipelineHealer now expects the full failure-type-specific key set to be present in `error_details` for the chosen `failure_type`. If the model returns malformed JSON or omits required typed keys, the LLM payload is rejected and PipelineHealer falls back to deterministic diagnosis data when available. Rejected payloads may leave observability fields such as `llm_payload_rejected`, `llm_payload_rejection_reason`, and `llm_payload_candidate_count` in `error_details`.
 
 Common examples:
 - `dependency`: `package_name`, `package_manager`, `manifest_file`, `required_version`, `resolution_kind`

--- a/docs/LLM_AND_AGENT_RUNTIME.md
+++ b/docs/LLM_AND_AGENT_RUNTIME.md
@@ -1,6 +1,6 @@
 # LLM and Agent Runtime
 
-<!-- LAST_VERIFIED: 803e871 -->
+<!-- LAST_VERIFIED: 1bee670 -->
 
 This document is the operator-facing contract for how PipelineHealer uses LLMs and agents at runtime.
 
@@ -52,6 +52,7 @@ Fallback behavior:
 - malformed JSON is rejected
 - incomplete typed payloads are rejected
 - when rejection happens, PipelineHealer falls back to deterministic diagnosis when available instead of trusting partial LLM prose
+- fallback diagnoses may carry `llm_payload_rejected`, `llm_payload_rejection_reason`, and `llm_payload_candidate_count` in `error_details` for auditability
 
 Operator implication:
 - a model that can answer loosely in natural language but cannot satisfy the structured diagnosis contract is not full-capability for diagnosis


### PR DESCRIPTION
## Summary
- address the merged #123 review finding by removing the conflicting mixed error_details example from the diagnosis prompt
- add rejection telemetry to diagnosis fallbacks so discarded LLM payloads leave auditable context in error_details
- document the new rejection visibility in the API and runtime docs

## Verification
- pytest -q backend/tests/test_diagnosis.py backend/tests/test_github_tools.py backend/tests/test_llm_provider_contracts.py
- mypy src
- python3 -m py_compile backend/src/agents/diagnosis.py backend/src/tools/github_tools.py

## Notes
- this continues the v0.6.0 hardening pass by making LLM diagnosis rejection visible instead of silent while keeping deterministic fallback behavior