### PR TITLE
Clarify learning retrieval contract follow-up

### DIFF
--- a/docs/DIAGNOSIS_REMEDIATION_ARCHITECTURE_PLAN.md
+++ b/docs/DIAGNOSIS_REMEDIATION_ARCHITECTURE_PLAN.md
@@ -1,4 +1,4 @@
-<!-- LAST_VERIFIED: 803e871 -->
+<!-- LAST_VERIFIED: 3480bec -->
 
 # Diagnosis and Remediation Architecture Plan
 
@@ -319,7 +319,7 @@ Active learning artifacts should inject structured context before diagnosis or r
 
 Recommended integration:
 
-1. retrieve matching approved or active playbooks
+1. retrieve matching active playbooks only (`approved` remains a governance state, not a runtime retrieval source)
 2. map them into structured context fields
 3. allow diagnosis/remediation to reference them explicitly
 4. record whether the playbook improved or degraded the outcome

--- a/docs/LEARNING_SYSTEM_PLAN.md
+++ b/docs/LEARNING_SYSTEM_PLAN.md
@@ -1,6 +1,6 @@
 # Learning System Plan
 
-<!-- LAST_VERIFIED: 60e2c27 -->
+<!-- LAST_VERIFIED: 3480bec -->
 
 This document explains the learning/governance subsystem, how to use it today, and what is planned next.
 
@@ -120,20 +120,23 @@ When active learning artifacts are injected into diagnosis/remediation, the runt
 should pass structured records, not freeform prompt stuffing.
 
 Recommended injected fields per matched artifact:
-- `candidate_id`
+- `id` (matching `LearningQueueItem.id`; a runtime adapter may alias this as `candidate_id` externally)
 - `title`
 - `reason_code`
 - `suggested_playbook`
-- `applicability_notes`
-- `risk_notes`
-- `evidence_summary`
-- `verification_summary`
+- `applicability_notes` (planned governed or derived notes about when the playbook applies)
+- `risk_notes` (planned governed or derived notes about residual or introduced risk)
+- `evidence_summary` (planned derived summary of the key evidence that led to this candidate)
+- `verification_summary` (planned derived summary of verification outcomes and operator feedback)
 - `match_basis`
+- `match_rank`
+- `match_score`
 
 Recommended runtime rules:
 - inject only `active` artifacts
+- `approved` artifacts remain pre-activation governance records and are not injected into live diagnosis/remediation
 - keep retrieval read-only; no activation or mutation in the diagnosis/remediation path
-- inject a bounded number of matches with explicit ranking metadata
+- inject a bounded number of matches with explicit ranking metadata (`match_rank`, `match_score`, and `match_basis`)
 - preserve deterministic evidence as the primary source of truth
 - treat learning context as advisory unless a later contract explicitly promotes it to a governed action path
 


### PR DESCRIPTION
## Summary
- update the architecture plan LAST_VERIFIED marker after the checklist edit
- align retrieval docs with the current learning queue model (`id` vs `candidate_id`)
- clarify that only `active` artifacts are injected at runtime and make ranking metadata explicit

## Verification
- doc review only
