### PR TITLE
Add activity verification workspace and incident detail upgrade

### DIFF
--- a/docs/FUTURE_PLAN.md
+++ b/docs/FUTURE_PLAN.md
@@ -137,11 +137,10 @@ Theme: operator workflow maturity and trust-first incident operations.
 
 ### Delivery Shape
 
-Recommended implementation split: `2-3` PRs, not one monolith and not many small PRs.
+Recommended implementation shape: a small number of focused PRs, not one monolith and not many tiny PRs.
 
-1. PR 1: verification workspace + feedback UX
-2. PR 2: Activity Detail + Control Center explainability/trust-surface redesign
-3. PR 3: review queue + trust reporting, if scope still warrants it after PR 1/2 land
+1. Combined PR: verification workspace + feedback UX + Activity Detail incident-record upgrade
+2. Follow-on PR(s): Control Center explainability/trust surface, review queue, and operator trust reporting, if the remaining scope still warrants separate changes after the combined PR lands
 
 Because `v0.6.0` has not been cut yet, this slice remains in the active `v0.6.0` release scope rather than rolling forward to a new target version.
 

--- a/frontend/src/components/activity/VerificationWorkspace.tsx
+++ b/frontend/src/components/activity/VerificationWorkspace.tsx
@@ -154,7 +154,9 @@ export default function VerificationWorkspace({
             : undefined,
         notes: notes.trim() || undefined,
         issue_number:
-          parsedIssueNumber !== null && Number.isFinite(parsedIssueNumber)
+          parsedIssueNumber !== null &&
+          Number.isFinite(parsedIssueNumber) &&
+          parsedIssueNumber >= 1
             ? parsedIssueNumber
             : undefined,
         issue_url: issueUrl.trim() || undefined,

--- a/frontend/src/components/activity/verification.ts
+++ b/frontend/src/components/activity/verification.ts
@@ -77,8 +77,10 @@ export function getVerificationHistory(
     .map((entry) => parseVerificationEntry(entry))
     .filter((entry): entry is VerificationEntry => entry !== null)
     .sort((a, b) => {
-      const left = a.recordedAt ? Date.parse(a.recordedAt) : 0;
-      const right = b.recordedAt ? Date.parse(b.recordedAt) : 0;
+      const leftParsed = a.recordedAt ? Date.parse(a.recordedAt) : 0;
+      const rightParsed = b.recordedAt ? Date.parse(b.recordedAt) : 0;
+      const left = Number.isFinite(leftParsed) ? leftParsed : 0;
+      const right = Number.isFinite(rightParsed) ? rightParsed : 0;
       return right - left;
     });
 }

--- a/frontend/src/pages/ActivityDetail.tsx
+++ b/frontend/src/pages/ActivityDetail.tsx
@@ -1084,7 +1084,7 @@ export default function ActivityDetail() {
       ]
         .filter(Boolean)
         .join(" • ")
-    : "Failure context was captured from the pipeline run and stored with this activity.";
+    : "Failure context was not captured for this pipeline run.";
   const remediationOutcomeSummary = activity.remediation_result
     ? `${formatActionTaken(activity.remediation_result.action_taken)} ${activity.remediation_result.success ? "completed successfully" : "did not complete successfully"}.`
     : "No remediation artifact was published for this activity.";


### PR DESCRIPTION
## Summary
- add the first `v0.6.0` operator verification workspace directly on Activity Detail using the existing learning feedback API
- restructure Activity Detail into an incident-record flow with clearer sections for what happened, what PipelineHealer concluded, what it did, and what still needs review
- keep the follow-on operator workflow maturity slice explicitly tracked under unreleased `v0.6.0` in `docs/FUTURE_PLAN.md`

## Verification
- `cd frontend && bun run lint`
- `cd frontend && ./node_modules/.bin/tsc --noEmit`
- `cd frontend && ./node_modules/.bin/vite build`

## Notes
- this is PR 1 of the tracked `v0.6.0` maturity slice (`BL-059` + initial `BL-060`)
- I will wait for the auto review comments before merging
