### PR TITLE
docs: align current release baseline before release cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-<!-- LAST_VERIFIED: 9c5cc40 -->
+<!-- LAST_VERIFIED: e1852d3 -->
 
 All notable changes to this project will be documented in this file.
 
@@ -8,7 +8,22 @@ The format is based on Keep a Changelog and this repo uses Semantic Versioning.
 
 ## [Unreleased]
 
-- _No unreleased entries yet._
+### Added
+
+- In-product verification workspace on Activity Detail for identification, diagnosis, remediation, and guidance-effectiveness feedback.
+- Control Center trust-ops surfaces for learning explainability, review queue triage, and trust reporting.
+
+### Changed
+
+- Hardened diagnosis and remediation around typed failure-specific contracts, deterministic evidence extraction, bounded patch drafting, and eval-gated rollout checks.
+- Injected governed learning context back into diagnosis and remediation flows, with operator-visible traceability and applied-guidance audit details.
+- Upgraded Activity Detail into an incident-record view and refreshed the public docs, demo runbooks, and architecture diagrams to match the current operator workflow.
+
+### Fixed
+
+- Replaced generic dependency, test, timeout, and build-config suggestions with more specific deterministic guidance and issue wording.
+- Linked generated review issues to active human fix PRs and closed superseded PipelineHealer issues more reliably.
+- Tightened diagnosis payload rejection handling, mypy/static-analysis reporting, and retrieval/runtime validation gaps surfaced by live CI incidents.
 
 ## [v0.5.9] - 2026-03-08
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # PipelineHealer
 
-<!-- LAST_VERIFIED: c9f507b -->
+<!-- LAST_VERIFIED: e1852d3 -->
 
 > OSS-first, policy-aware pipeline remediation platform with GitHub Actions and Jenkins bridge support today.
 
 [![Live Demo](https://img.shields.io/badge/Live_Demo-Try_It-brightgreen)](https://ca-canepro-ph-frontend.kinddune-53ac219d.eastus2.azurecontainerapps.io)
 [![Azure](https://img.shields.io/badge/Azure-Deployed-blue)](https://azure.microsoft.com)
-[![Release](https://img.shields.io/badge/Release-v0.5.7-blue)](https://github.com/Canepro/pipelinehealer/releases/tag/v0.5.7)
+[![Release](https://img.shields.io/badge/Release-v0.5.9-blue)](https://github.com/Canepro/pipelinehealer/releases/tag/v0.5.9)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
 PipelineHealer ingests failed pipeline executions, diagnoses root causes, and applies controlled remediation:
@@ -27,8 +27,8 @@ Current operator surfaces on `main`:
 
 - Public repository: `https://github.com/Canepro/pipelinehealer`
 - Live reference deployment: Azure Container Apps (backend + frontend)
-- Current release baseline: [`v0.5.7`](https://github.com/Canepro/pipelinehealer/releases/tag/v0.5.7)
-- Current forward track: post-`v0.5.7` continuity and follow-on release planning
+- Current release baseline: [`v0.5.9`](https://github.com/Canepro/pipelinehealer/releases/tag/v0.5.9)
+- Current forward track: post-`v0.5.9` continuity and follow-on release planning
 - Current `main` branch focus: unreleased `v0.6.0` hardening and operator workflow maturity, including verification feedback and trust-ops surfaces
 - `v0.3.2` required freeze scope shipped: `#36` (Jenkins bridge), `#42` (Assign-to-Agent), `#57` (storage posture hardening)
 - OSS-friendly durable storage is available: PostgreSQL adapter (`#58`) alongside Cosmos DB and in-memory development mode
@@ -158,7 +158,7 @@ Detailed docs:
 Azure model-path note:
 - when using `cognitiveservices.azure.com`, set `AZURE_OPENAI_ENDPOINT` to the base resource URL only
 - some models support Azure Responses API but reject Chat Completions; if you test with a Responses-only model, validate with `bash scripts/ph.sh aoai:check` against the target release
-- as of `v0.5.7`, the validated high-confidence Azure path for `gpt-5.1-codex-mini` is the `cognitiveservices.azure.com` base endpoint with the Responses-first runtime path
+- as of `v0.5.9`, the validated high-confidence Azure path for `gpt-5.1-codex-mini` is the `cognitiveservices.azure.com` base endpoint with the Responses-first runtime path
 
 LLM/runtime reference:
 - detailed capability, routing, degraded-mode, and validated-combination guidance now lives in [docs/LLM_AND_AGENT_RUNTIME.md](docs/LLM_AND_AGENT_RUNTIME.md)
@@ -205,6 +205,14 @@ Treat live LLM compatibility as a release gate for demos and production posture,
 - Operator clarity: the app shell can surface the running UI/API release version so deployed state is visible without external tooling.
 
 ## Recent Releases
+
+### v0.5.9
+
+- Capability-validation follow-up patch: recent validation evidence is now paged instead of truncated, latest matching validation is selected by freshness, and capability surfaces stay aligned with the runtime semantics contract.
+
+### v0.5.8
+
+- Capability-transparency patch: Settings and Control Center now distinguish configured, provider-ready, operation-compatible, full-capability, degraded, and scaffolded runtime states.
 
 ### v0.5.7
 
@@ -273,11 +281,11 @@ Treat live LLM compatibility as a release gate for demos and production posture,
 - No-rebuild config updates through runtime env sync paths (ACA/Helm/compose).
 - Release workflow/frontend image decoupled from auth build-arg coupling.
 
-Release notes: [CHANGELOG.md](CHANGELOG.md), [v0.5.7 release](https://github.com/Canepro/pipelinehealer/releases/tag/v0.5.7), [v0.5.6 release](https://github.com/Canepro/pipelinehealer/releases/tag/v0.5.6), and [v0.5.5 release](https://github.com/Canepro/pipelinehealer/releases/tag/v0.5.5)
+Release notes: [CHANGELOG.md](CHANGELOG.md), [v0.5.9 release](https://github.com/Canepro/pipelinehealer/releases/tag/v0.5.9), [v0.5.8 release](https://github.com/Canepro/pipelinehealer/releases/tag/v0.5.8), and [v0.5.7 release](https://github.com/Canepro/pipelinehealer/releases/tag/v0.5.7)
 
 ## Kubernetes Portability Status
 
-As of March 8, 2026 (`v0.5.7`), random-user image pullability regressions are gated in release automation.
+As of March 8, 2026 (`v0.5.9`), random-user image pullability regressions are gated in release automation.
 
 - previous portability gap issue [#37](https://github.com/Canepro/pipelinehealer/issues/37) is closed
 - Helm success output alone is still not sufficient proof; verify rollout and image pulls on clean clusters

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # PipelineHealer API Reference
 
-<!-- LAST_VERIFIED: 85beac6 -->
+<!-- LAST_VERIFIED: e1852d3 -->
 
 This document describes the PipelineHealer backend REST API, authentication model, request/response contracts, and best practices.
 
@@ -87,7 +87,7 @@ Unauthenticated health check.
 ```json
 {
   "service": "PipelineHealer",
-  "version": "0.5.7",
+  "version": "0.5.9",
   "status": "healthy",
   "environment": "production",
   "storage_backend": "cosmos_db"

--- a/docs/DEMO_SCRIPT.md
+++ b/docs/DEMO_SCRIPT.md
@@ -1,6 +1,6 @@
 # PipelineHealer Demo Recording Guide (Single-File Runbook)
 
-<!-- LAST_VERIFIED: c9f507b -->
+<!-- LAST_VERIFIED: e1852d3 -->
 
 Use this as the only doc during recording day. It includes:
 
@@ -36,7 +36,7 @@ Remaining submission item this doc drives: demo video length must be 2:00 max.
 Default values used in this runbook:
 
 ```bash
-export RELEASE_TAG="${RELEASE_TAG:-v0.5.7}"
+export RELEASE_TAG="${RELEASE_TAG:-v0.5.9}"
 export DEMO_REPO="${DEMO_REPO:-Canepro/pipelinehealer-demo}"
 ```
 

--- a/docs/FUTURE_PLAN.md
+++ b/docs/FUTURE_PLAN.md
@@ -49,6 +49,8 @@ This roadmap is version-driven. Backlog work is planned against target releases,
 | `v0.5.5` | Released | Final summary-panel separation cleanup + release/doc alignment carry-forward |
 | `v0.5.6` | Released | Azure `Responses`-first compatibility fix + clipboard hardening + deployment runbook lessons |
 | `v0.5.7` | Released | Post-review release-discipline patch + CLI smoke-check hardening |
+| `v0.5.8` | Released | LLM capability transparency in backend settings and operator UI |
+| `v0.5.9` | Released | Capability-validation evidence freshness and paging hardening |
 
 ## Released Target: `v0.5.7` (Patch)
 

--- a/docs/HACKATHON_LOG.md
+++ b/docs/HACKATHON_LOG.md
@@ -36,12 +36,14 @@ This is the long-form project tracker for hackathon execution status, submission
   - required scope locked to `#36/#42/#57` for submission reliability
   - `#58` (PostgreSQL adapter) was implemented only after required scope was complete, CI green, and docs synced
   - storage extensibility remained adapter-scoped (no core workflow rewrites during freeze)
-- Release `v0.5.7` is the current public baseline.
-- `v0.5.7` shipped:
-  - `demo:proof` now preserves flag parsing when `--repo` is missing a value or is followed by another flag
-  - `aoai:check` now collapses Responses API request/JSON failures into concise operator-facing errors
-  - protected-branch release docs now make post-review tagging explicit so release tags track the reviewed branch commit rather than a pre-review candidate
-- Post-`v0.5.7` follow-on work is continuity and release planning, not demo-scope product correction.
+- Release `v0.5.9` is the current public baseline.
+- `v0.5.8` shipped:
+  - Settings and Control Center now distinguish configured, provider-ready, operation-compatible, full-capability, degraded, and scaffolded runtime states
+- `v0.5.9` shipped:
+  - capability validation now scans recent evidence via paging instead of truncating at the first 100 activities
+  - latest matching validation is selected by freshest evidence rather than assuming creation order
+  - runtime semantics stay aligned across backend capability summaries and frontend surfaces
+- Post-`v0.5.9` follow-on work is continuity and release planning, not demo-scope product correction.
 - Historical `v0.5.0` planning target is now shipped:
   - deployment-facing Assign-to-Agent receiver boundary
   - generic outbound event and notification routing

--- a/docs/LLM_AND_AGENT_RUNTIME.md
+++ b/docs/LLM_AND_AGENT_RUNTIME.md
@@ -1,6 +1,6 @@
 # LLM and Agent Runtime
 
-<!-- LAST_VERIFIED: e008e2a -->
+<!-- LAST_VERIFIED: e1852d3 -->
 
 This document is the operator-facing contract for how PipelineHealer uses LLMs and agents at runtime.
 
@@ -106,7 +106,7 @@ Practical interpretation:
 
 ## Validated Azure Behavior
 
-Validated on `v0.5.7`:
+Validated on `v0.5.9`:
 
 1. `https://<resource>.cognitiveservices.azure.com/`
 - `gpt-5.1-codex-mini`

--- a/docs/LOCAL_DEMO_RUNBOOK.md
+++ b/docs/LOCAL_DEMO_RUNBOOK.md
@@ -1,6 +1,6 @@
 # Local Demo Runbook (PipelineHealer)
 
-<!-- LAST_VERIFIED: c9f507b -->
+<!-- LAST_VERIFIED: e1852d3 -->
 
 This guide walks you through setting up PipelineHealer locally, triggering CI failures in a demo repo, and verifying the results on the dashboard.
 
@@ -118,7 +118,7 @@ In the Azure Portal, open your OpenAI resource page → **Keys and Endpoint**:
 
 > **Note:** If your endpoint uses the `cognitiveservices.azure.com` domain, that works too. PipelineHealer prefers the Azure Responses API first and falls back to Chat only when a deployment rejects Responses.
 
-Validated Azure combinations as of `v0.5.7`:
+Validated Azure combinations as of `v0.5.9`:
 - stable default path: `https://<resource>.openai.azure.com/` with `gpt-5-mini`
 - validated stronger diagnosis/remediation path: `https://<resource>.cognitiveservices.azure.com/` with `gpt-5.1-codex-mini`
 


### PR DESCRIPTION
## Summary
- fill the changelog unreleased section with the v0.6.0 work already landed on main
- align current-release references from v0.5.7 to the actual published baseline v0.5.9
- carry the current published baseline through the demo/API/runtime docs and internal release tracking

## Verification
- bash scripts/check_version_sync.sh
- git diff --check
