### PR TITLE
docs: add published demo video link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # PipelineHealer
 
-<!-- LAST_VERIFIED: d4b972c -->
+<!-- LAST_VERIFIED: e2b5f2c -->
 
 > OSS-first, policy-aware pipeline remediation platform for failed delivery workflows.
 
 [![Live Demo](https://img.shields.io/badge/Live_Demo-Try_It-brightgreen)](https://ca-canepro-ph-frontend.kinddune-53ac219d.eastus2.azurecontainerapps.io)
+[![Demo Video](https://img.shields.io/badge/Demo_Video-YouTube-red)](https://youtu.be/9iv5ZMKYzts)
 [![Azure](https://img.shields.io/badge/Azure-Deployed-blue)](https://azure.microsoft.com)
 [![Release](https://img.shields.io/badge/Release-v0.6.0-blue)](https://github.com/Canepro/pipelinehealer/releases/tag/v0.6.0)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
@@ -43,6 +44,7 @@ Pipeline failures create repetitive triage work and slow delivery. PipelineHeale
 - Native provider path: GitHub Actions
 - Bridge path: Jenkins
 - Reference managed deployment: Azure Container Apps
+- Demo video: [YouTube walkthrough](https://youtu.be/9iv5ZMKYzts)
 - Latest release: [`v0.6.0`](https://github.com/Canepro/pipelinehealer/releases/tag/v0.6.0)
 - Detailed release history: [CHANGELOG.md](CHANGELOG.md)
 

--- a/docs/HACKATHON_LOG.md
+++ b/docs/HACKATHON_LOG.md
@@ -159,7 +159,8 @@ This is the long-form project tracker for hackathon execution status, submission
 - [x] Working project deployed to Azure (`azd up` equivalent infra + app deployment validated)
 - [x] Public GitHub repository
 - [x] Project description (features/problem/technologies) in `README.md`
-- [ ] Demo video (2 min max)
+- [x] Demo video (2 min max)
+  - Published: `https://youtu.be/9iv5ZMKYzts`
 - [x] Architecture diagram (Mermaid in `README.md`)
 - [x] Microsoft Learn profile URL(s) captured for all participants:
   - Vincent Mogah: `https://learn.microsoft.com/en-us/users/canepro0084/`
@@ -613,11 +614,12 @@ This plan is the source of truth for controlled polish work without drift.
 - [x] Freeze feature changes; only bugfix/doc updates.
 - [x] Refresh proof artifacts and links in `README`.
 - [ ] Final demo rehearsal using `docs/DEMO_SCRIPT.md`.
-- [ ] Produce final 2-minute video and submission package.
+- [x] Produce final 2-minute video.
+  - Published: `https://youtu.be/9iv5ZMKYzts`
+- [ ] Finish submission package.
 
 ## Known Risks / Follow-Ups
 
-- Demo video is still open.
 - Agentic workflow parent/no-op tracker issues (`#18`, `#24`) are automation-managed and may remain open without affecting submission quality.
 - Auto-fix branch collision risk is mitigated by per-run branch naming (`...-run-<workflow_run_id>`); monitor for edge-case Git ref conflicts.
 - Dependency remediations currently focus on manifest changes and may not update lockfiles in all package-manager variants.


### PR DESCRIPTION
This pull request updates documentation to reflect the completion and publication of the project's demo video. The README and project logs now include a direct link to the demo video, and checklist items related to the video have been marked as completed.

Demo video updates:

* Added a badge and link to the published demo video in the `README.md` header and feature summary section. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R8) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R47)
* Updated hackathon log checklists in `docs/HACKATHON_LOG.md` to mark the demo video as completed, including the publication link. [[1]](diffhunk://#diff-f98ebd636c28fff8e1808988ad73da08755b54b2d7ee771d452ec5ac168cd801L162-R163) [[2]](diffhunk://#diff-f98ebd636c28fff8e1808988ad73da08755b54b2d7ee771d452ec5ac168cd801L616-L620)