### PR TITLE
docs(release): sync v0.6.1 shipped state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # PipelineHealer
 
-<!-- LAST_VERIFIED: 6ed6cee -->
+<!-- LAST_VERIFIED: 8ebafda -->
 
 > OSS-first, policy-aware pipeline remediation platform for failed delivery workflows.
 
 [![Live Demo](https://img.shields.io/badge/Live_Demo-Try_It-brightgreen)](https://ca-canepro-ph-frontend.kinddune-53ac219d.eastus2.azurecontainerapps.io)
 [![Demo Video](https://img.shields.io/badge/Demo_Video-YouTube-red)](https://youtu.be/9iv5ZMKYzts)
 [![Azure](https://img.shields.io/badge/Azure-Deployed-blue)](https://azure.microsoft.com)
-[![Release](https://img.shields.io/badge/Release-v0.6.1-blue)](https://github.com/Canepro/pipelinehealer/releases/latest)
+[![Release](https://img.shields.io/badge/Release-v0.6.1-blue)](https://github.com/Canepro/pipelinehealer/releases/tag/v0.6.1)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
 PipelineHealer ingests failed pipeline runs, normalizes the failure context, diagnoses likely root causes, and chooses a policy-safe remediation path.
@@ -45,7 +45,7 @@ Pipeline failures create repetitive triage work and slow delivery. PipelineHeale
 - Bridge path: Jenkins
 - Reference managed deployment: Azure Container Apps
 - Demo video: [YouTube walkthrough](https://youtu.be/9iv5ZMKYzts)
-- Latest release: [`v0.6.1`](https://github.com/Canepro/pipelinehealer/releases/latest)
+- Latest release: [`v0.6.1`](https://github.com/Canepro/pipelinehealer/releases/tag/v0.6.1)
 - Detailed release history: [CHANGELOG.md](CHANGELOG.md)
 
 Example remediation stories:

--- a/docs/DEMO_SCRIPT.md
+++ b/docs/DEMO_SCRIPT.md
@@ -1,6 +1,6 @@
 # PipelineHealer Demo Recording Guide (Single-File Runbook)
 
-<!-- LAST_VERIFIED: 6ed6cee -->
+<!-- LAST_VERIFIED: 8ebafda -->
 
 Use this as the only doc during recording day. It includes:
 
@@ -36,11 +36,11 @@ Remaining submission item this doc drives: demo video length must be 2:00 max.
 Default values used in this runbook:
 
 ```bash
-export RELEASE_TAG="${RELEASE_TAG:-$(git describe --tags --abbrev=0 2>/dev/null || echo v0.6.0)}"
+export RELEASE_TAG="${RELEASE_TAG:-$(git describe --tags --abbrev=0 2>/dev/null || echo v0.6.1)}"
 export DEMO_REPO="${DEMO_REPO:-Canepro/pipelinehealer-demo}"
 ```
 
-Keep `RELEASE_TAG` pinned to the latest published tag for recording. The default above resolves to the latest local tag when available and falls back to `v0.6.0` if tags have not been fetched yet. Do not point the demo flow at an untagged local branch or unreleased commit.
+Keep `RELEASE_TAG` pinned to the latest published tag for recording. The default above resolves to the latest local tag when available and falls back to `v0.6.1` if tags have not been fetched yet. Do not point the demo flow at an untagged local branch or unreleased commit.
 If `DEMO_REPO` is not exported in your shell, either run the export block above first or omit `--repo` and let `bash scripts/ph.sh demo:proof` fall back to the default demo repo.
 
 ## Recording Plan (2 Minutes Max)

--- a/docs/FUTURE_PLAN.md
+++ b/docs/FUTURE_PLAN.md
@@ -54,7 +54,7 @@ This roadmap is version-driven. Backlog work is planned against target releases,
 | `v0.6.0` | Released | Diagnosis/remediation hardening + learning-ops rework + operator workflow maturity |
 | `v0.6.1` | Released | Jenkins bridge low-evidence trust hardening + dashboard drill-down reliability |
 
-## Release Target: `v0.6.1` (Patch)
+## Released Target: `v0.6.1` (Patch)
 
 Theme: Jenkins bridge low-evidence trust hardening and operator-copy cleanup.
 

--- a/docs/HACKATHON_LOG.md
+++ b/docs/HACKATHON_LOG.md
@@ -36,7 +36,7 @@ This is the long-form project tracker for hackathon execution status, submission
   - required scope locked to `#36/#42/#57` for submission reliability
   - `#58` (PostgreSQL adapter) was implemented only after required scope was complete, CI green, and docs synced
   - storage extensibility remained adapter-scoped (no core workflow rewrites during freeze)
-- Release `v0.6.1` is the current release candidate on this branch and becomes the public baseline once the tag is pushed.
+- Release `v0.6.1` is the current public baseline.
 - `v0.5.8` shipped:
   - Settings and Control Center now distinguish configured, provider-ready, operation-compatible, full-capability, degraded, and scaffolded runtime states
 - `v0.5.9` shipped:


### PR DESCRIPTION
## Summary
- treat v0.6.1 consistently as shipped across release docs
- pin README release links to the v0.6.1 tag instead of a moving latest-release URL
- update the demo script fallback so missing local tags still default to v0.6.1

## Verification
- verified local branch/tag state after commit
- force-updated remote tag v0.6.1 to the shipped-state sync commit
- attempted direct push to main and confirmed branch protection requires PR flow