### PR TITLE
feat: add jenkins bridge integration kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-<!-- LAST_VERIFIED: 6ed6cee -->
+<!-- LAST_VERIFIED: d555eef -->
 
 All notable changes to this project will be documented in this file.
 
@@ -8,7 +8,13 @@ The format is based on Keep a Changelog and this repo uses Semantic Versioning.
 
 ## [Unreleased]
 
-- _No unreleased entries yet._
+### Added
+
+- Added a reusable Jenkins bridge integration kit under `integrations/jenkins-bridge`, including an install script, direct-excerpt capture helper, and Jenkinsfile example for Jenkins-first repos.
+
+### Changed
+
+- Standardized the recommended Jenkins evidence-capture pattern around plugin-free workspace excerpts and repo-local shell sender assets instead of script-approval-sensitive Groovy log access.
 
 ## [v0.6.1] - 2026-03-12
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PipelineHealer
 
-<!-- LAST_VERIFIED: 8ebafda -->
+<!-- LAST_VERIFIED: d555eef -->
 
 > OSS-first, policy-aware pipeline remediation platform for failed delivery workflows.
 
@@ -47,6 +47,26 @@ Pipeline failures create repetitive triage work and slow delivery. PipelineHeale
 - Demo video: [YouTube walkthrough](https://youtu.be/9iv5ZMKYzts)
 - Latest release: [`v0.6.1`](https://github.com/Canepro/pipelinehealer/releases/tag/v0.6.1)
 - Detailed release history: [CHANGELOG.md](CHANGELOG.md)
+
+## Jenkins Integration Kit
+
+PipelineHealer now ships a reusable Jenkins integration kit for OSS and
+Jenkins-first environments under
+[integrations/jenkins-bridge/](integrations/jenkins-bridge/README.md).
+
+What it provides:
+
+- signed bridge sender assets you can drop into `.jenkins/scripts/`
+- a plugin-free shell capture helper for direct failure excerpts
+- a small install script for repeatable repo onboarding
+- a documented rollout path from repo-local scripts to a Shared Library model
+
+Recommended Jenkins baseline:
+
+- no extra plugin required for the supported shell-capture path
+- Shared Libraries if you want org-wide reuse
+- avoid `currentBuild.rawBuild` or other script-approval-heavy patterns for
+  routine bridge evidence capture
 
 Example remediation stories:
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # PipelineHealer API Reference
 
-<!-- LAST_VERIFIED: 6ed6cee -->
+<!-- LAST_VERIFIED: d555eef -->
 
 This document describes the PipelineHealer backend REST API, authentication model, request/response contracts, and best practices.
 
@@ -161,6 +161,11 @@ Receives GitHub `workflow_run` webhook events. This is the primary ingest point 
 #### `POST /webhook/jenkins`
 
 Receives signed Jenkins bridge payloads when `JENKINS_BRIDGE_ENABLED=true`.
+
+Supported sender assets for Jenkins-first repos are shipped in
+[`integrations/jenkins-bridge/`](../integrations/jenkins-bridge/README.md).
+The recommended repo-side capture path is plugin-free workspace excerpt capture,
+with `PH_LOG_EXCERPT_FILE` exported before invoking the bridge sender.
 
 Required headers:
 

--- a/docs/FUTURE_PLAN.md
+++ b/docs/FUTURE_PLAN.md
@@ -1,6 +1,6 @@
 # Future Plan (Versioned Roadmap)
 
-<!-- LAST_VERIFIED: 6d2dd4e -->
+<!-- LAST_VERIFIED: d555eef -->
 
 This roadmap is version-driven. Backlog work is planned against target releases, not ad-hoc phases.
 
@@ -53,6 +53,33 @@ This roadmap is version-driven. Backlog work is planned against target releases,
 | `v0.5.9` | Released | Capability-validation evidence freshness and paging hardening |
 | `v0.6.0` | Released | Diagnosis/remediation hardening + learning-ops rework + operator workflow maturity |
 | `v0.6.1` | Released | Jenkins bridge low-evidence trust hardening + dashboard drill-down reliability |
+
+## Release Target: `v0.7.0` (Minor)
+
+Theme: reusable Jenkins integration kit and evidence-first bridge capture.
+
+### Must-Have Scope
+
+1. Reusable Jenkins integration assets
+   - publish a supported Jenkins bridge install kit inside the PipelineHealer repo
+   - include sender, tooling bootstrap, evidence helper, and Jenkinsfile example assets
+2. Repeatable onboarding pattern
+   - support repo-local adoption first, with a documented Shared Library rollout path for larger Jenkins estates
+   - keep the integration portable across OSS Jenkins, multibranch jobs, PR jobs, and scheduled jobs
+3. Evidence quality hardening
+   - standardize on direct workspace-captured excerpts using a plugin-free shell wrapper
+   - avoid script-approval-sensitive Groovy APIs as the primary guidance path
+4. Documentation and release clarity
+   - document the supported Jenkins plugin baseline and failure-path expectations
+   - keep this release scoped to bridge evidence quality and packaging, not native Jenkins provider parity
+
+### Exit Criteria
+
+1. The PipelineHealer repo ships a documented Jenkins integration kit under `integrations/jenkins-bridge`.
+2. Repo maintainers can install the bridge assets into a Jenkins repo with one command and a documented Jenkinsfile snippet.
+3. The recommended capture pattern produces `log_excerpt` bridge evidence on a real failing Jenkins build.
+4. Docs clearly distinguish the supported plugin-free capture pattern from non-portable script-approval-heavy alternatives.
+5. The work lands as `v0.7.0`, `minor`, and `Added`/`Changed` scoped PRs.
 
 ## Released Target: `v0.6.1` (Patch)
 

--- a/docs/JENKINS_BRIDGE_TECHNICAL_DESIGN.md
+++ b/docs/JENKINS_BRIDGE_TECHNICAL_DESIGN.md
@@ -1,6 +1,6 @@
 # BL-034 Technical Design: Jenkins Bridge Ingestion
 
-<!-- LAST_VERIFIED: fadd4cf -->
+<!-- LAST_VERIFIED: d555eef -->
 
 Status: Implemented (design + implementation reference)  
 Backlog: `BL-034`  
@@ -240,6 +240,37 @@ Phase 2:
 
 Phase 3:
 - evaluate native Jenkins adapter scope (`BL-035`)
+
+## Supported Jenkins Integration Pattern
+
+The supported Jenkins-side assets now live in
+`integrations/jenkins-bridge/`.
+
+Preferred rollout:
+
+1. repo-local `.jenkins/scripts/` drop-in for first adoption
+2. controller-level Shared Library standardization after the pattern is proven
+
+Preferred evidence path:
+
+- capture the failing shell block into a workspace file with a repo-local shell
+  wrapper
+- export `PH_LOG_EXCERPT_FILE` in `post { failure { ... } }`
+- invoke `send-pipelinehealer-bridge.sh` as the final notifier
+
+Why this is the supported pattern:
+
+- it avoids `currentBuild.rawBuild` and other script-approval-sensitive APIs
+- it works on locked-down controllers and OSS Jenkins setups
+- it produces direct, bounded excerpts instead of depending on `consoleText`
+  scraping
+
+Plugin guidance:
+
+- no extra plugin required for the supported path
+- optional: Shared Libraries for org-wide reuse
+- optional: `Pipeline Utility Steps` when teams want a local `tee` wrapper
+- not required: custom PipelineHealer Jenkins plugins
 
 ## Open Questions
 

--- a/docs/LOCAL_DEMO_RUNBOOK.md
+++ b/docs/LOCAL_DEMO_RUNBOOK.md
@@ -1,6 +1,6 @@
 # Local Demo Runbook (PipelineHealer)
 
-<!-- LAST_VERIFIED: e2b5f2c -->
+<!-- LAST_VERIFIED: d555eef -->
 
 This guide walks you through setting up PipelineHealer locally, triggering CI failures in a demo repo, and verifying the results on the dashboard.
 
@@ -282,6 +282,7 @@ Enable Jenkins bridge only when you are receiving signed `POST /webhook/jenkins`
 - `JENKINS_BRIDGE_ALLOW_PR=false` is the default safe posture (bridge events stay issue-first).
 - To allow bridge-triggered PR output, set both `JENKINS_BRIDGE_ALLOW_PR=true` and `AUTO_CREATE_PR=true`.
 - The Settings page now includes a Jenkins Bridge setup assistant that generates a sample payload and a signed `curl` smoke test from an ephemeral bridge URL + shared secret input.
+- For repo-side sender assets and the supported evidence-capture pattern, use [integrations/jenkins-bridge/README.md](../integrations/jenkins-bridge/README.md).
 
 Optional external diagnostics fast-path tuning:
 

--- a/docs/OPERATOR_CONTROL_PLANE.md
+++ b/docs/OPERATOR_CONTROL_PLANE.md
@@ -1,4 +1,4 @@
-<!-- LAST_VERIFIED: c9f507b -->
+<!-- LAST_VERIFIED: d555eef -->
 
 # Operator Control Plane
 
@@ -125,6 +125,12 @@ Examples:
 - provider credentials for third-party integrations
 
 These should expose both configuration state and dependency state.
+
+For Jenkins specifically, the supported sender path should stay portable:
+
+- repo-local or Shared Library managed bridge assets
+- plugin-free failure excerpt capture as the baseline path
+- no requirement for custom Jenkins plugins or controller-local script approvals
 
 ## Provenance Model
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Docs Index
 
-<!-- LAST_VERIFIED: e2b5f2c -->
+<!-- LAST_VERIFIED: d555eef -->
 
 Use this index to find the right doc quickly.
 
@@ -37,6 +37,7 @@ These stable screenshots reflect the current hosted operator experience and are 
 - `RELEASE_RUNBOOK.md` — release prep, semver bump, tag/publish verification, and rollback guidance
 - `PREDEPLOY_PLACEHOLDER_AUDIT.md` — pre-deploy stop-ship checklist
 - `../infra/terraform/README.md` — manual Terraform equivalent of the Azure reference Bicep stack
+- `../integrations/jenkins-bridge/README.md` — reusable Jenkins bridge install kit, supported rollout patterns, and failure-capture guidance
 
 ### Tier 3 — Internal/Transient (author discretion; archive post-submission)
 

--- a/integrations/jenkins-bridge/README.md
+++ b/integrations/jenkins-bridge/README.md
@@ -1,0 +1,135 @@
+# Jenkins Bridge Integration Kit
+
+<!-- LAST_VERIFIED: d555eef -->
+
+Reusable Jenkins-side assets for PipelineHealer's signed Jenkins bridge.
+
+Use this kit when Jenkins is the primary CI system and you want failed jobs to
+create PipelineHealer activities with direct, bounded failure evidence instead
+of summary-only bridge context.
+
+## Support Stance
+
+Recommended rollout order:
+
+1. Use these files as a repo-local drop-in under `.jenkins/scripts/`.
+2. Standardize the same pattern later via a Jenkins Shared Library if your
+   controller manages many repos.
+3. Keep the sender shell-based so it works on vanilla controllers and does not
+   require a custom Jenkins plugin.
+
+Preferred Jenkins support:
+
+- no extra plugin required for the supported shell-capture path
+- optional: Jenkins Shared Libraries for org-wide reuse
+- optional: `Pipeline Utility Steps` if you want a Groovy `tee` wrapper locally
+- intentionally avoided: `currentBuild.rawBuild` or other script-approval-heavy
+  APIs, because they do not scale cleanly across OSS or locked-down controllers
+
+## Files
+
+- `install.sh`
+  - Copies the supported bridge assets into a target repo's
+    `.jenkins/scripts/` directory
+  - Optionally copies examples into `.jenkins/examples/`
+- `send-pipelinehealer-bridge.sh`
+  - Signs and sends the Jenkins bridge payload to `POST /webhook/jenkins`
+  - Prefers `PH_LOG_EXCERPT_FILE` or `PH_LOG_EXCERPT`
+  - Falls back to a best-effort `consoleText` scrape only when no direct
+    excerpt is provided
+  - Infers repository and commit metadata when Jenkins env wiring is partial
+- `prepare-failure-tooling.sh`
+  - Installs minimal failure-path dependencies on common agent images
+  - Keeps bridge notification best-effort instead of turning a tooling miss
+    into a second failure
+- `capture-pipelinehealer-bridge-excerpt.sh`
+  - Captures the stdout/stderr of an inline shell script into a workspace file
+  - Preserves the wrapped command's exit code
+  - Works on stock Jenkins agents without requiring the Jenkins `tee` step
+- `pipelinehealer-bridge-evidence.groovy`
+  - Optional Groovy helper when your controller already supports the Jenkins
+    `tee` step
+  - Not the required path for OSS portability
+- `examples/Jenkinsfile.failure-snippet.groovy`
+  - Minimal failure-path pattern for direct use or Shared Library wrapping
+
+## Install
+
+From the PipelineHealer repo root:
+
+```bash
+bash integrations/jenkins-bridge/install.sh /path/to/your-repo --with-examples
+```
+
+That creates:
+
+- `.jenkins/scripts/send-pipelinehealer-bridge.sh`
+- `.jenkins/scripts/prepare-failure-tooling.sh`
+- `.jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh`
+- `.jenkins/scripts/pipelinehealer-bridge-evidence.groovy`
+- optional: `.jenkins/examples/Jenkinsfile.failure-snippet.groovy`
+
+## Recommended Jenkinsfile Pattern
+
+1. Wrap the shell step most likely to fail with the shell capture helper.
+2. Export `PH_LOG_EXCERPT_FILE` from the failure block before invoking the
+   sender.
+3. Keep workspace cleanup in `post { cleanup { ... } }`, not before the bridge
+   notifier runs.
+
+Example:
+
+```groovy
+stage('Terraform Plan') {
+  steps {
+    sh '''
+      cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+      terraform plan -no-color -input=false -out=tfplan
+SCRIPT
+    '''
+  }
+}
+
+post {
+  failure {
+    script {
+      sh '''
+        set +e
+        if [ -f .jenkins/scripts/prepare-failure-tooling.sh ]; then
+          sh .jenkins/scripts/prepare-failure-tooling.sh || true
+        fi
+        export PH_REPOSITORY="owner/repo"
+        export PH_FAILURE_STAGE="terraform-plan"
+        export PH_FAILURE_SUMMARY="Jenkins Terraform plan failed"
+        if [ -f "${WORKSPACE}/.pipelinehealer-log-excerpt.txt" ]; then
+          export PH_LOG_EXCERPT_FILE="${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+        fi
+        bash .jenkins/scripts/send-pipelinehealer-bridge.sh >/dev/null || \
+          echo "WARNING: Failed to notify PipelineHealer bridge"
+      '''
+    }
+  }
+  cleanup {
+    cleanWs()
+  }
+}
+```
+
+## Why This Pattern Is Preferred
+
+Direct workspace excerpt capture is more reliable than scraping
+`${BUILD_URL}/consoleText`.
+
+Benefits:
+
+- works even when Jenkins UI/API auth is restricted
+- keeps evidence local to the failing build context
+- sends bounded, LLM-usable evidence instead of only a short summary
+- does not require Jenkins script approval exceptions or extra controller plugins
+- stays portable across multibranch, PR, and scheduled Jenkins jobs
+
+For the backend contract and rollout guidance, see
+[docs/JENKINS_BRIDGE_TECHNICAL_DESIGN.md](../../docs/JENKINS_BRIDGE_TECHNICAL_DESIGN.md).
+
+For the minimal snippet, see
+[examples/Jenkinsfile.failure-snippet.groovy](examples/Jenkinsfile.failure-snippet.groovy).

--- a/integrations/jenkins-bridge/capture-pipelinehealer-bridge-excerpt.sh
+++ b/integrations/jenkins-bridge/capture-pipelinehealer-bridge-excerpt.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+set -eu
+
+OUTPUT_FILE="${1:?usage: capture-pipelinehealer-bridge-excerpt.sh <output-file>}"
+CAPTURE_SHELL="${PH_CAPTURE_SHELL:-/bin/sh}"
+STATUS_FILE="$(mktemp)"
+SCRIPT_FILE="$(mktemp)"
+trap 'rm -f "$STATUS_FILE" "$SCRIPT_FILE"' EXIT
+
+mkdir -p "$(dirname "$OUTPUT_FILE")"
+cat > "$SCRIPT_FILE"
+chmod +x "$SCRIPT_FILE"
+
+if [ ! -x "$CAPTURE_SHELL" ] && ! command -v "$CAPTURE_SHELL" >/dev/null 2>&1; then
+  echo "PipelineHealer bridge capture: shell not found: $CAPTURE_SHELL" >&2
+  exit 1
+fi
+
+if ! command -v tee >/dev/null 2>&1; then
+  echo "PipelineHealer bridge capture: tee is unavailable" >&2
+  exit 1
+fi
+
+(
+  set +e
+  "$CAPTURE_SHELL" -e "$SCRIPT_FILE" 2>&1
+  echo $? > "$STATUS_FILE"
+) | tee "$OUTPUT_FILE"
+
+STATUS="$(cat "$STATUS_FILE" 2>/dev/null || echo 1)"
+if [ "$STATUS" -eq 0 ]; then
+  rm -f "$OUTPUT_FILE"
+fi
+exit "$STATUS"

--- a/integrations/jenkins-bridge/examples/Jenkinsfile.failure-snippet.groovy
+++ b/integrations/jenkins-bridge/examples/Jenkinsfile.failure-snippet.groovy
@@ -1,0 +1,33 @@
+stage('Validation') {
+  steps {
+    sh '''
+      cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+      ./scripts/run-validation.sh
+SCRIPT
+    '''
+  }
+}
+
+post {
+  failure {
+    script {
+      sh '''
+        set +e
+        if [ -f .jenkins/scripts/prepare-failure-tooling.sh ]; then
+          sh .jenkins/scripts/prepare-failure-tooling.sh || true
+        fi
+        export PH_REPOSITORY="owner/repo"
+        export PH_FAILURE_STAGE="validation"
+        export PH_FAILURE_SUMMARY="Jenkins validation failed"
+        if [ -f "${WORKSPACE}/.pipelinehealer-log-excerpt.txt" ]; then
+          export PH_LOG_EXCERPT_FILE="${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+        fi
+        bash .jenkins/scripts/send-pipelinehealer-bridge.sh >/dev/null || \
+          echo "WARNING: Failed to notify PipelineHealer bridge"
+      '''
+    }
+  }
+  cleanup {
+    cleanWs()
+  }
+}

--- a/integrations/jenkins-bridge/install.sh
+++ b/integrations/jenkins-bridge/install.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: bash integrations/jenkins-bridge/install.sh <target-repo> [--with-examples]
+
+Copies the supported PipelineHealer Jenkins bridge assets into the target repo:
+  .jenkins/scripts/send-pipelinehealer-bridge.sh
+  .jenkins/scripts/prepare-failure-tooling.sh
+  .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh
+  .jenkins/scripts/pipelinehealer-bridge-evidence.groovy
+
+Optional:
+  --with-examples   also copy .jenkins/examples/Jenkinsfile.failure-snippet.groovy
+EOF
+}
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  usage
+  exit 1
+fi
+
+TARGET_REPO="$1"
+WITH_EXAMPLES="${2:-}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ -n "$WITH_EXAMPLES" && "$WITH_EXAMPLES" != "--with-examples" ]]; then
+  echo "Unknown option: $WITH_EXAMPLES" >&2
+  usage
+  exit 1
+fi
+
+if [[ ! -d "$TARGET_REPO" ]]; then
+  echo "Target repo does not exist: $TARGET_REPO" >&2
+  exit 1
+fi
+
+mkdir -p "$TARGET_REPO/.jenkins/scripts"
+
+cp "$SCRIPT_DIR/send-pipelinehealer-bridge.sh" \
+  "$TARGET_REPO/.jenkins/scripts/send-pipelinehealer-bridge.sh"
+cp "$SCRIPT_DIR/prepare-failure-tooling.sh" \
+  "$TARGET_REPO/.jenkins/scripts/prepare-failure-tooling.sh"
+cp "$SCRIPT_DIR/capture-pipelinehealer-bridge-excerpt.sh" \
+  "$TARGET_REPO/.jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh"
+cp "$SCRIPT_DIR/pipelinehealer-bridge-evidence.groovy" \
+  "$TARGET_REPO/.jenkins/scripts/pipelinehealer-bridge-evidence.groovy"
+
+chmod +x "$TARGET_REPO/.jenkins/scripts/send-pipelinehealer-bridge.sh"
+chmod +x "$TARGET_REPO/.jenkins/scripts/prepare-failure-tooling.sh"
+chmod +x "$TARGET_REPO/.jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh"
+
+if [[ "$WITH_EXAMPLES" == "--with-examples" ]]; then
+  mkdir -p "$TARGET_REPO/.jenkins/examples"
+  cp "$SCRIPT_DIR/examples/Jenkinsfile.failure-snippet.groovy" \
+    "$TARGET_REPO/.jenkins/examples/Jenkinsfile.failure-snippet.groovy"
+fi
+
+cat <<EOF
+Installed PipelineHealer Jenkins bridge assets into:
+  $TARGET_REPO/.jenkins/scripts
+
+Next steps:
+1. Wire the capture helper around the step most likely to fail.
+2. Export PH_REPOSITORY, PH_FAILURE_STAGE, and PH_FAILURE_SUMMARY in post { failure { ... } }.
+3. Export PH_LOG_EXCERPT_FILE before invoking send-pipelinehealer-bridge.sh.
+4. Keep workspace cleanup in post { cleanup { ... } }.
+EOF

--- a/integrations/jenkins-bridge/pipelinehealer-bridge-evidence.groovy
+++ b/integrations/jenkins-bridge/pipelinehealer-bridge-evidence.groovy
@@ -1,0 +1,33 @@
+def capture(String outputPath = '.pipelinehealer-log-excerpt.txt', Closure body) {
+  tee(file: outputPath) {
+    body()
+  }
+}
+
+def writeLogExcerpt(String outputPath = '.pipelinehealer-log-excerpt.txt', int maxLines = 200, int maxChars = 20000) {
+  if (!fileExists(outputPath)) {
+    echo 'PipelineHealer bridge evidence: no captured excerpt file is available yet.'
+    return false
+  }
+
+  String content = readFile(outputPath)
+  if (content == null) {
+    echo 'PipelineHealer bridge evidence: captured excerpt file could not be read.'
+    return false
+  }
+
+  if (maxChars > 0 && content.length() > maxChars) {
+    content = content.substring(content.length() - maxChars)
+  }
+
+  List<String> lines = content.readLines()
+  if (maxLines > 0 && lines.size() > maxLines) {
+    lines = lines.takeRight(maxLines)
+  }
+
+  String excerpt = lines.join('\n')
+  writeFile file: outputPath, text: excerpt ? "${excerpt}\n" : ''
+  return true
+}
+
+return this

--- a/integrations/jenkins-bridge/prepare-failure-tooling.sh
+++ b/integrations/jenkins-bridge/prepare-failure-tooling.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+set -u
+
+warn() {
+  echo "Failure tooling bootstrap: $*" >&2
+}
+
+missing_tools() {
+  missing=""
+  for tool in bash curl jq openssl tail tee tr; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      missing="$missing $tool"
+    fi
+  done
+  printf '%s\n' "${missing# }"
+}
+
+MISSING="$(missing_tools)"
+[ -z "$MISSING" ] && exit 0
+
+warn "missing tools:${MISSING}"
+
+if command -v apk >/dev/null 2>&1; then
+  apk add --no-cache bash ca-certificates coreutils curl jq openssl >/dev/null 2>&1 || {
+    warn "apk install failed"
+    exit 0
+  }
+  update-ca-certificates >/dev/null 2>&1 || true
+  exit 0
+fi
+
+if command -v apt-get >/dev/null 2>&1; then
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update >/dev/null 2>&1 || {
+    warn "apt-get update failed"
+    exit 0
+  }
+  apt-get install -y bash ca-certificates coreutils curl jq openssl >/dev/null 2>&1 || {
+    warn "apt-get install failed"
+    exit 0
+  }
+  update-ca-certificates >/dev/null 2>&1 || true
+  exit 0
+fi
+
+warn "no supported package manager found; continuing without installing tools"
+exit 0

--- a/integrations/jenkins-bridge/send-pipelinehealer-bridge.sh
+++ b/integrations/jenkins-bridge/send-pipelinehealer-bridge.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+warn() {
+  echo "PipelineHealer bridge: $*" >&2
+}
+
+trim() {
+  local value="${1:-}"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+json_escape() {
+  local value="${1:-}"
+  value="$(printf '%s' "$value" | LC_ALL=C tr -d '\000-\010\013\014\016-\037')"
+  value=${value//\\/\\\\}
+  value=${value//\"/\\\"}
+  value=${value//$'\n'/\\n}
+  value=${value//$'\r'/}
+  value=${value//$'\t'/\\t}
+  value=${value//$'\f'/\\f}
+  value=${value//$'\b'/\\b}
+  printf '%s' "$value"
+}
+
+extract_url_path() {
+  local url="$1"
+  local without_scheme rest
+
+  case "$url" in
+    http://*) without_scheme="${url#http://}" ;;
+    https://*) without_scheme="${url#https://}" ;;
+    *) return 1 ;;
+  esac
+
+  [[ -n "$without_scheme" ]] || return 1
+  [[ "$without_scheme" == */* ]] || {
+    printf '/\n'
+    return 0
+  }
+
+  rest="${without_scheme#*/}"
+  rest="${rest#/}"
+  rest="${rest%%\?*}"
+  rest="${rest%%\#*}"
+  printf '/%s\n' "$rest"
+}
+
+extract_url_host() {
+  local url="$1"
+  local without_scheme
+
+  case "$url" in
+    http://*) without_scheme="${url#http://}" ;;
+    https://*) without_scheme="${url#https://}" ;;
+    *) return 1 ;;
+  esac
+
+  without_scheme="${without_scheme%%/*}"
+  without_scheme="${without_scheme%%\?*}"
+  without_scheme="${without_scheme%%\#*}"
+  printf '%s\n' "$without_scheme"
+}
+
+sanitize_commit_sha() {
+  local commit="${1:-}"
+  if [[ "$commit" =~ ^[0-9a-fA-F]{40}$ ]]; then
+    printf '%s\n' "$commit"
+  else
+    printf '\n'
+  fi
+}
+
+extract_repository_from_git_url() {
+  local url="${1:-}"
+  local repo=""
+
+  case "$url" in
+    https://github.com/*)
+      repo="${url#https://github.com/}"
+      ;;
+    http://github.com/*)
+      repo="${url#http://github.com/}"
+      ;;
+    ssh://git@github.com/*)
+      repo="${url#ssh://git@github.com/}"
+      ;;
+    git@github.com:*)
+      repo="${url#git@github.com:}"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  repo="${repo%.git}"
+  repo="${repo#/}"
+  [[ "$repo" == */* ]] || return 1
+  printf '%s\n' "$repo"
+}
+
+infer_repository() {
+  local candidate=""
+  local remote_url=""
+
+  for candidate in "${PH_REPOSITORY:-}" "${GITHUB_REPOSITORY:-}"; do
+    candidate="$(trim "$candidate")"
+    if [[ -n "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  for remote_url in "${GIT_URL:-}" "${PH_GIT_URL:-}"; do
+    remote_url="$(trim "$remote_url")"
+    if [[ -n "$remote_url" ]] && candidate="$(extract_repository_from_git_url "$remote_url" 2>/dev/null)"; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  if command -v git >/dev/null 2>&1; then
+    remote_url="$(git config --get remote.origin.url 2>/dev/null || true)"
+    remote_url="$(trim "$remote_url")"
+    if [[ -n "$remote_url" ]] && candidate="$(extract_repository_from_git_url "$remote_url" 2>/dev/null)"; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  fi
+
+  warn "could not infer repository; set PH_REPOSITORY explicitly. Skipping notification."
+  printf '\n'
+}
+
+infer_commit_sha() {
+  local commit=""
+
+  for commit in "${PH_COMMIT_SHA:-}" "${GIT_COMMIT:-}"; do
+    commit="$(sanitize_commit_sha "$commit")"
+    if [[ -n "$commit" ]]; then
+      printf '%s\n' "$commit"
+      return 0
+    fi
+  done
+
+  if command -v git >/dev/null 2>&1; then
+    commit="$(git rev-parse HEAD 2>/dev/null || true)"
+    commit="$(sanitize_commit_sha "$commit")"
+    if [[ -n "$commit" ]]; then
+      printf '%s\n' "$commit"
+      return 0
+    fi
+  fi
+
+  printf '\n'
+}
+
+parse_int() {
+  local value="${1:-0}"
+  if [[ "$value" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$value"
+  else
+    printf '0\n'
+  fi
+}
+
+if [[ -z "${PH_BRIDGE_URL:-}" || -z "${PH_BRIDGE_SECRET:-}" ]]; then
+  warn "missing PH_BRIDGE_URL or PH_BRIDGE_SECRET; skipping notification"
+  exit 0
+fi
+
+for cmd in curl openssl tail tr; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    warn "required command '$cmd' is unavailable; skipping notification"
+    exit 0
+  fi
+done
+
+TARGET_URL="${PH_BRIDGE_URL%/}"
+TARGET_PATH="$(extract_url_path "$TARGET_URL")" || {
+  warn "invalid PH_BRIDGE_URL '${PH_BRIDGE_URL}'"
+  exit 0
+}
+
+TIMESTAMP="$(date +%s)"
+NONCE="${PH_NONCE:-jenkins-${JOB_NAME:-job}-${BUILD_NUMBER:-0}-${TIMESTAMP}}"
+BODY_FILE="$(mktemp)"
+EXCERPT_FILE="$(mktemp)"
+trap 'rm -f "$BODY_FILE" "$EXCERPT_FILE"' EXIT
+
+if [[ -n "${PH_LOG_EXCERPT:-}" ]]; then
+  printf '%s\n' "${PH_LOG_EXCERPT}" >"$EXCERPT_FILE"
+elif [[ -n "${PH_LOG_EXCERPT_FILE:-}" && -f "${PH_LOG_EXCERPT_FILE}" ]]; then
+  cat "${PH_LOG_EXCERPT_FILE}" >"$EXCERPT_FILE"
+else
+  JOB_URL="${PH_JOB_URL:-${BUILD_URL:-}}"
+  if [[ -n "$JOB_URL" ]]; then
+    curl -fsSL "${JOB_URL%/}/consoleText" >"$EXCERPT_FILE" 2>/dev/null || true
+  fi
+fi
+
+RAW_EXCERPT=""
+MAX_LINES="$(parse_int "${PH_LOG_EXCERPT_MAX_LINES:-120}")"
+MAX_CHARS="$(parse_int "${PH_LOG_EXCERPT_MAX_CHARS:-20000}")"
+if [[ -f "$EXCERPT_FILE" ]]; then
+  RAW_EXCERPT="$(tail -n "$MAX_LINES" "$EXCERPT_FILE" 2>/dev/null || true)"
+  if [[ -n "$RAW_EXCERPT" ]]; then
+    RAW_EXCERPT="$(printf '%s' "$RAW_EXCERPT" | tail -c "$MAX_CHARS")"
+  fi
+fi
+
+JOB_URL="${PH_JOB_URL:-${BUILD_URL:-}}"
+JOB_HOST="$(extract_url_host "$JOB_URL" 2>/dev/null || true)"
+JOB_NAME="${PH_JOB_NAME:-${JOB_NAME:-jenkins-job}}"
+SUMMARY="${PH_FAILURE_SUMMARY:-Jenkins job ${JOB_NAME} failed}"
+BUILD_NUMBER="$(parse_int "${PH_BUILD_NUMBER:-${BUILD_NUMBER:-0}}")"
+DURATION_MS="$(parse_int "${PH_DURATION_MS:-0}")"
+COMMIT_SHA="$(infer_commit_sha)"
+REPOSITORY="$(infer_repository)"
+SENT_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+if [[ -z "$REPOSITORY" ]]; then
+  exit 0
+fi
+
+cat >"$BODY_FILE" <<EOF
+{
+  "schema_version": "1.0",
+  "provider": "jenkins",
+  "delivery_id": "$(json_escape "jenkins:${JOB_NAME}#${BUILD_NUMBER}")",
+  "sent_at": "$(json_escape "$SENT_AT")",
+  "repository": "$(json_escape "$REPOSITORY")",
+  "branch": "$(json_escape "${PH_BRANCH:-${GIT_BRANCH:-${BRANCH_NAME:-unknown}}}")",
+  "commit_sha": "$(json_escape "$COMMIT_SHA")",
+  "job": {
+    "name": "$(json_escape "$JOB_NAME")",
+    "url": "$(json_escape "$JOB_URL")",
+    "build_number": ${BUILD_NUMBER},
+    "result": "$(json_escape "${PH_RESULT:-FAILURE}")",
+    "duration_ms": ${DURATION_MS}
+  },
+  "failure": {
+    "stage": "$(json_escape "${PH_FAILURE_STAGE:-}")",
+    "step": "$(json_escape "${PH_FAILURE_STEP:-}")",
+    "command": "$(json_escape "${PH_FAILURE_COMMAND:-}")",
+    "summary": "$(json_escape "$SUMMARY")",
+    "log_excerpt": "$(json_escape "$RAW_EXCERPT")"
+  },
+  "artifacts": [],
+  "metadata": {
+    "jenkins_instance": "$(json_escape "$JOB_HOST")",
+    "job_name": "$(json_escape "$JOB_NAME")",
+    "build_url": "$(json_escape "$JOB_URL")"
+  }
+}
+EOF
+
+BODY_SHA_OUTPUT="$(openssl dgst -sha256 "$BODY_FILE")"
+BODY_SHA="${BODY_SHA_OUTPUT##* }"
+CANONICAL="$(printf 'POST\n%s\n%s\n%s\n%s' "$TARGET_PATH" "$TIMESTAMP" "$NONCE" "$BODY_SHA")"
+SIGNATURE_OUTPUT="$(printf '%s' "$CANONICAL" | openssl dgst -sha256 -hmac "$PH_BRIDGE_SECRET")"
+SIGNATURE="sha256=${SIGNATURE_OUTPUT##* }"
+
+curl -fsS -X POST "$TARGET_URL" \
+  -H "Content-Type: application/json" \
+  -H "X-PH-Bridge-Provider: jenkins" \
+  -H "X-PH-Bridge-Timestamp: $TIMESTAMP" \
+  -H "X-PH-Bridge-Nonce: $NONCE" \
+  -H "X-PH-Bridge-Signature: $SIGNATURE" \
+  --data-binary @"$BODY_FILE"


### PR DESCRIPTION
This pull request introduces a reusable Jenkins bridge integration kit for PipelineHealer, focusing on plugin-free, evidence-first failure capture and standardized onboarding for Jenkins-first repositories. The integration kit includes install scripts, shell helpers, and example assets, with updated documentation across the project to reflect the new recommended patterns and rollout guidance.

**Jenkins Integration Kit and Evidence Capture**

* Added a new `integrations/jenkins-bridge` directory containing:
  - [`install.sh`](diffhunk://#diff-4c6725cc8f99c157e0bce86cf0508e6914bffdfd2fc042a1805d004b40fc7889R1-R63): Installs bridge assets into a target repo for easy onboarding.
  - [`capture-pipelinehealer-bridge-excerpt.sh`](diffhunk://#diff-3e397e95f233df8c7ec6933bf5f7a5b603b7f3f72550c948c51e2e5d0b1eec04R1-R26): Plugin-free shell wrapper to capture failure output into a workspace file, preserving exit codes.
  - [`prepare-failure-tooling.sh`](diffhunk://#diff-ed146307bd5098a6eff4b33584da9cd24646da4004bbc2edc9a3628af3ade227R1-R47): Installs required tools on common Jenkins agent images, handling missing dependencies gracefully.
  - [`pipelinehealer-bridge-evidence.groovy`](diffhunk://#diff-b66e84942e3a0047de7e6ff9caf67907784ba162d15fbb987db3db1fb83f03d6R1-R16): Optional Groovy helper for controllers with `tee` support.
  - Example Jenkinsfile snippet for direct use or Shared Library wrapping.
* Updated documentation to recommend plugin-free workspace excerpt capture and repo-local sender assets over Groovy log access, improving portability and reliability. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R17) [[2]](diffhunk://#diff-7ade1beab7ef41e127af1ee47f719225af1f91c728eb577699f4e802cfae228dR244-R274)

**Documentation and Rollout Guidance**

* Added and updated references to the Jenkins bridge integration kit and its usage in multiple docs, including `README.md`, `docs/API.md`, `docs/LOCAL_DEMO_RUNBOOK.md`, and `docs/README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R51-R70) [[2]](diffhunk://#diff-b57590968a12cee85a37c1b91d8cc7092cd8b68e50b242c39a178121db82a797R165-R169) [[3]](diffhunk://#diff-27ea8feb12b14646e16c869070641a42a57159a4b3dea7096e955f0ca7d562a7R285) [[4]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R40)
* Provided detailed technical design, rollout patterns, and plugin baseline guidance in `docs/JENKINS_BRIDGE_TECHNICAL_DESIGN.md`.
* Updated roadmap and release planning to reflect the integration kit and evidence-first bridge capture as the theme for the upcoming minor release (`v0.7.0`).

**Operator and Provenance Model Updates**

* Clarified Jenkins integration portability and plugin-free baseline in operator control plane documentation.

**Project Metadata**

* Updated `CHANGELOG.md` and verification tags across documentation to reflect the new Jenkins bridge integration kit and evidence-capture pattern. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R17) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3) [[3]](diffhunk://#diff-b57590968a12cee85a37c1b91d8cc7092cd8b68e50b242c39a178121db82a797L3-R3) [[4]](diffhunk://#diff-f14227faa42c2c2dc3e964e46fe76a843a6b72e07e6018e491b7af7b013010f3L3-R3) [[5]](diffhunk://#diff-7ade1beab7ef41e127af1ee47f719225af1f91c728eb577699f4e802cfae228dL3-R3) [[6]](diffhunk://#diff-27ea8feb12b14646e16c869070641a42a57159a4b3dea7096e955f0ca7d562a7L3-R3) [[7]](diffhunk://#diff-0a2d3c9429d2abf532d763523d2af869b93bc1c82728d4dd85ae3b5e0f1117caL1-R1) [[8]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L3-R3)

---

**References:**  
[[1]](diffhunk://#diff-4c6725cc8f99c157e0bce86cf0508e6914bffdfd2fc042a1805d004b40fc7889R1-R63) [[2]](diffhunk://#diff-3e397e95f233df8c7ec6933bf5f7a5b603b7f3f72550c948c51e2e5d0b1eec04R1-R26) [[3]](diffhunk://#diff-ed146307bd5098a6eff4b33584da9cd24646da4004bbc2edc9a3628af3ade227R1-R47) [[4]](diffhunk://#diff-b66e84942e3a0047de7e6ff9caf67907784ba162d15fbb987db3db1fb83f03d6R1-R16) [[5]](diffhunk://#diff-392e0bf883ac4b8f426c0e1f115e2d1688be8b76397e58ff84ca432f2b37df24R1-R33) [[6]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R17) [[7]](diffhunk://#diff-7ade1beab7ef41e127af1ee47f719225af1f91c728eb577699f4e802cfae228dR244-R274) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R51-R70) [[9]](diffhunk://#diff-b57590968a12cee85a37c1b91d8cc7092cd8b68e50b242c39a178121db82a797R165-R169) [[10]](diffhunk://#diff-27ea8feb12b14646e16c869070641a42a57159a4b3dea7096e955f0ca7d562a7R285) [[11]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R40) [[12]](diffhunk://#diff-f14227faa42c2c2dc3e964e46fe76a843a6b72e07e6018e491b7af7b013010f3R57-R83) [[13]](diffhunk://#diff-0a2d3c9429d2abf532d763523d2af869b93bc1c82728d4dd85ae3b5e0f1117caR129-R134)