### PR TITLE
fix: harden settings persistence, storage startup, and hybrid admin auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-<!-- LAST_VERIFIED: c78ae9b -->
+<!-- LAST_VERIFIED: c8c77c8 -->
 
 All notable changes to this project will be documented in this file.
 
@@ -10,12 +10,18 @@ The format is based on Keep a Changelog and this repo uses Semantic Versioning.
 
 ### Added
 
-- Added a reusable Jenkins bridge integration kit under `integrations/jenkins-bridge`, including an install script, direct-excerpt capture helper, and Jenkinsfile example for Jenkins-first repos.
+- Added a reusable Jenkins bridge integration kit under `integrations/jenkins-bridge`, including an install script, direct-excerpt capture helper, and Jenkinsfile example for Jenkins-first repos. (`c78ae9b`)
 
 ### Changed
 
-- Standardized the recommended Jenkins evidence-capture pattern around plugin-free workspace excerpts and repo-local shell sender assets instead of script-approval-sensitive Groovy log access.
-- Reorganized the docs into `docs/reference/`, `docs/runbooks/`, `docs/architecture/`, and `docs/archive/` so current operator guidance is easier to find and historical planning material no longer competes with the canonical docs.
+- Standardized the recommended Jenkins evidence-capture pattern around plugin-free workspace excerpts and repo-local shell sender assets instead of script-approval-sensitive Groovy log access. (`ae22c4e`)
+- Reorganized the docs into `docs/reference/`, `docs/runbooks/`, `docs/architecture/`, and `docs/archive/` so current operator guidance is easier to find and historical planning material no longer competes with the canonical docs. (`d555eef`)
+
+### Fixed
+
+- Restored default settings persistence and env-only redeploy path resolution so checkout-based runtimes target the actual backend `.env` and repo helper scripts without requiring explicit `PIPELINEHEALER_ENV_FILE_PATH` or `PIPELINEHEALER_REPO_ROOT` overrides.
+- Stopped development startup from forcing in-memory storage over explicit `STORAGE_MODE=cosmos` or `STORAGE_MODE=postgres`, so local durable-storage validation now matches the real app boot path.
+- Restored hybrid admin-key fallback behavior for signed-in browser sessions so a valid `X-Admin-Key` can override a non-admin bearer session, while blank admin-key headers still fall back to bearer auth.
 
 ## [v0.6.1] - 2026-03-12
 

--- a/backend/src/api/dashboard.py
+++ b/backend/src/api/dashboard.py
@@ -996,7 +996,6 @@ def _extract_learning_candidates(
         candidate.promotion_readiness = _evaluate_learning_promotion_readiness(candidate)
         candidates.append(candidate)
 
-    candidates_by_id = {candidate.id: candidate for candidate in candidates}
     for candidate in candidates:
         guidance_metrics = _compute_guidance_metrics(candidate.id, activities)
         candidate.guidance_application_count = int(guidance_metrics["guidance_application_count"])
@@ -1013,13 +1012,26 @@ def _extract_learning_candidates(
     return candidates
 
 
+def _backend_root() -> Path:
+    """Resolve the backend project root for local and container layouts."""
+    current = Path(__file__).resolve()
+    for candidate in current.parents:
+        if (candidate / "pyproject.toml").exists() and (candidate / "src").is_dir():
+            return candidate
+    return current.parents[2]
+
+
 def _repo_root() -> Path:
     """Resolve repository root for helper command/script execution."""
     override = os.getenv("PIPELINEHEALER_REPO_ROOT", "").strip()
     if override:
         return Path(override).resolve()
-    # backend/src/api/dashboard.py -> repo root is 2 levels up (/app in container).
-    return Path(__file__).resolve().parents[2]
+
+    backend_root = _backend_root()
+    for candidate in (backend_root, *backend_root.parents):
+        if (candidate / "scripts" / "ph.sh").exists():
+            return candidate
+    return backend_root
 
 
 def _env_file_path() -> Path:
@@ -1027,7 +1039,7 @@ def _env_file_path() -> Path:
     override = os.getenv("PIPELINEHEALER_ENV_FILE_PATH", "").strip()
     if override:
         return Path(override).resolve()
-    return _repo_root() / "backend" / ".env"
+    return _backend_root() / ".env"
 
 
 def _env_bool(value: bool) -> str:

--- a/backend/src/api/security.py
+++ b/backend/src/api/security.py
@@ -268,6 +268,11 @@ async def require_admin_key(
         return
 
     if mode == "hybrid":
+        # An explicit admin key must be able to override an existing browser session.
+        if x_admin_key is not None and x_admin_key.strip():
+            _validate_admin_key_header(x_admin_key)
+            request.state.auth_principal = None
+            return
         if _extract_bearer_token(authorization):
             principal = get_request_principal(request) or _validate_bearer_token(authorization)
             _require_admin_role(principal)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -133,9 +133,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         log_level=settings.log_level,
     )
 
-    # Create and initialize workflow
-    use_in_memory = settings.environment == "development"
-    workflow = create_workflow(use_in_memory=use_in_memory)
+    # Create and initialize workflow using configured storage mode selection.
+    workflow = create_workflow()
     await workflow.initialize()
 
     # Store on app.state -- route handlers read via Depends(get_storage/get_workflow).

--- a/backend/tests/test_phase2_security.py
+++ b/backend/tests/test_phase2_security.py
@@ -415,6 +415,47 @@ async def test_settings_env_file_override_controls_startup_provenance(monkeypatc
     assert body["settings_metadata"]["heal_mode"]["source"] == "env"
 
 
+def test_dashboard_paths_default_to_backend_env_in_repo_checkout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    backend_root = repo_root / "backend"
+    fake_dashboard = backend_root / "src" / "api" / "dashboard.py"
+    fake_dashboard.parent.mkdir(parents=True)
+    fake_dashboard.write_text("# test fixture\n", encoding="utf-8")
+    (backend_root / "pyproject.toml").write_text("[project]\nname='pipelinehealer'\n", encoding="utf-8")
+    (repo_root / "scripts").mkdir(parents=True)
+    (repo_root / "scripts" / "ph.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+
+    monkeypatch.delenv("PIPELINEHEALER_REPO_ROOT", raising=False)
+    monkeypatch.delenv("PIPELINEHEALER_ENV_FILE_PATH", raising=False)
+    monkeypatch.setattr(dashboard, "__file__", str(fake_dashboard))
+
+    assert dashboard._backend_root() == backend_root
+    assert dashboard._repo_root() == repo_root
+    assert dashboard._env_file_path() == backend_root / ".env"
+
+
+def test_dashboard_paths_default_to_backend_env_in_container_layout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    backend_root = tmp_path / "app"
+    fake_dashboard = backend_root / "src" / "api" / "dashboard.py"
+    fake_dashboard.parent.mkdir(parents=True)
+    fake_dashboard.write_text("# test fixture\n", encoding="utf-8")
+    (backend_root / "pyproject.toml").write_text("[project]\nname='pipelinehealer'\n", encoding="utf-8")
+
+    monkeypatch.delenv("PIPELINEHEALER_REPO_ROOT", raising=False)
+    monkeypatch.delenv("PIPELINEHEALER_ENV_FILE_PATH", raising=False)
+    monkeypatch.setattr(dashboard, "__file__", str(fake_dashboard))
+
+    assert dashboard._backend_root() == backend_root
+    assert dashboard._repo_root() == backend_root
+    assert dashboard._env_file_path() == backend_root / ".env"
+
+
 @pytest.mark.asyncio
 async def test_settings_endpoint_requires_admin_key(monkeypatch) -> None:
     monkeypatch.setenv("ENVIRONMENT", "production")
@@ -978,6 +1019,78 @@ async def test_admin_patch_accepts_hybrid_gh_aw_ingestion_mode(monkeypatch) -> N
     )
     assert response.status_code == 200
     assert response.json()["gh_aw_ingestion_mode"] == "hybrid"
+
+
+@pytest.mark.asyncio
+async def test_hybrid_admin_key_can_override_non_admin_bearer_session(monkeypatch) -> None:
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("AUTH_MODE", "hybrid")
+    monkeypatch.setenv("API_AUTH_KEY", "hybrid-api-key")
+    monkeypatch.setenv("ADMIN_API_KEY", "admin-secret")
+    monkeypatch.setenv("ENTRA_TENANT_ID", "tenant-123")
+    monkeypatch.setenv("ENTRA_CLIENT_ID", "client-123")
+    monkeypatch.setenv("ENTRA_ADMIN_ROLES", "PipelineHealer.Admin")
+    reset_settings()
+
+    app.state.storage = InMemoryStorage()
+    app.state.workflow = _DummyWorkflow()  # type: ignore[assignment]
+
+    def _fake_validate(authorization: str | None) -> AuthPrincipal:
+        if authorization != "Bearer user-token":
+            raise HTTPException(status_code=401, detail="Invalid bearer token")
+        return AuthPrincipal(
+            subject="regular-user",
+            roles=frozenset({"PipelineHealer.Reader"}),
+            scopes=frozenset({"PipelineHealer.Access"}),
+            claims={"sub": "regular-user"},
+        )
+
+    monkeypatch.setattr(security, "_validate_bearer_token", _fake_validate)
+
+    response = await _patch_settings(
+        {"heal_mode": "safe"},
+        headers={"Authorization": "Bearer user-token", "X-Admin-Key": "admin-secret"},
+    )
+    assert response.status_code == 200
+
+    audit = await _get_settings_audit(
+        headers={"Authorization": "Bearer user-token", "X-Admin-Key": "admin-secret"},
+    )
+    assert audit.status_code == 200
+    entries = audit.json()
+    assert entries
+    assert entries[0]["actor"].startswith("admin_key:")
+
+
+@pytest.mark.asyncio
+async def test_hybrid_empty_admin_key_header_falls_back_to_bearer_auth(monkeypatch) -> None:
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("AUTH_MODE", "hybrid")
+    monkeypatch.setenv("API_AUTH_KEY", "hybrid-api-key")
+    monkeypatch.setenv("ADMIN_API_KEY", "admin-secret")
+    monkeypatch.setenv("ENTRA_TENANT_ID", "tenant-123")
+    monkeypatch.setenv("ENTRA_CLIENT_ID", "client-123")
+    monkeypatch.setenv("ENTRA_ADMIN_ROLES", "PipelineHealer.Admin")
+    reset_settings()
+
+    app.state.storage = InMemoryStorage()
+
+    def _fake_validate(authorization: str | None) -> AuthPrincipal:
+        if authorization != "Bearer admin-token":
+            raise HTTPException(status_code=401, detail="Invalid bearer token")
+        return AuthPrincipal(
+            subject="admin-user",
+            roles=frozenset({"PipelineHealer.Admin"}),
+            scopes=frozenset({"PipelineHealer.Access"}),
+            claims={"sub": "admin-user"},
+        )
+
+    monkeypatch.setattr(security, "_validate_bearer_token", _fake_validate)
+
+    response = await _get_settings(
+        headers={"Authorization": "Bearer admin-token", "X-Admin-Key": "   "}
+    )
+    assert response.status_code == 200
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_storage_mode_selection.py
+++ b/backend/tests/test_storage_mode_selection.py
@@ -1,7 +1,10 @@
 """Storage mode selection and non-development durability guardrail tests."""
 
+import asyncio
+
 import pytest
 
+from src import main as main_module
 from src.config import get_settings, reset_settings
 from src.storage import ActivityStorage, InMemoryStorage, PostgresStorage
 from src.workflows.pipeline_healer import create_storage, resolve_storage_mode
@@ -106,3 +109,54 @@ def test_explicit_postgres_mode_builds_postgres_storage(
 
     assert resolve_storage_mode(settings) == "postgres"
     assert isinstance(create_storage(settings), PostgresStorage)
+
+
+@pytest.mark.asyncio
+async def test_lifespan_does_not_force_in_memory_in_development(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.setenv("STORAGE_MODE", "postgres")
+    monkeypatch.setenv("POSTGRES_DSN", "postgresql://user:pass@localhost:5432/pipelinehealer")
+    reset_settings()
+
+    captured: dict[str, object] = {}
+
+    class _DummyWorkflow:
+        def __init__(self) -> None:
+            self.storage = object()
+
+        async def initialize(self) -> None:
+            captured["initialized"] = True
+
+        async def recover_stale_activities(self) -> int:
+            return 0
+
+        async def close(self) -> None:
+            captured["closed"] = True
+
+    def _fake_create_workflow(*, use_in_memory: bool = False) -> _DummyWorkflow:
+        captured["use_in_memory"] = use_in_memory
+        return _DummyWorkflow()
+
+    async def _fake_apply_persisted_runtime_settings(storage, workflow) -> None:  # type: ignore[no-untyped-def]
+        captured["applied"] = (storage, workflow)
+
+    async def _fake_backfill_sweep_loop(workflow) -> None:  # type: ignore[no-untyped-def]
+        await asyncio.sleep(3600)
+
+    monkeypatch.setattr(main_module, "create_workflow", _fake_create_workflow)
+    monkeypatch.setattr(
+        main_module.dashboard,
+        "apply_persisted_runtime_settings",
+        _fake_apply_persisted_runtime_settings,
+    )
+    monkeypatch.setattr(main_module, "_backfill_sweep_loop", _fake_backfill_sweep_loop)
+
+    test_app = main_module.create_app()
+    async with main_module.lifespan(test_app):
+        assert captured["use_in_memory"] is False
+        assert captured["initialized"] is True
+
+    assert "applied" in captured
+    assert captured["closed"] is True

--- a/docs/FUTURE_PLAN.md
+++ b/docs/FUTURE_PLAN.md
@@ -58,6 +58,12 @@ This roadmap is version-driven. Backlog work is planned against target releases,
 
 Theme: reusable Jenkins integration kit and evidence-first bridge capture.
 
+Carry-forward reliability scope already landed on `main` for inclusion in the `v0.7.0` release train:
+
+- settings persistence / env-only redeploy path resolution now correctly defaults to the backend checkout root without requiring explicit repo-root overrides
+- development startup now honors explicit durable `STORAGE_MODE` selection instead of always forcing in-memory storage
+- hybrid admin auth now allows a non-empty `X-Admin-Key` to override a signed-in non-admin bearer session while preserving bearer fallback for blank headers
+
 ### Must-Have Scope
 
 1. Reusable Jenkins integration assets


### PR DESCRIPTION
## Summary
- fix backend settings persistence/redeploy path resolution so checkout-based runtimes find the real backend `.env` and repo helper scripts by default
- stop development startup from forcing in-memory storage over explicit durable `STORAGE_MODE` selections
- restore hybrid admin-key override behavior for signed-in non-admin bearer sessions, while preserving bearer fallback for blank admin-key headers
- add targeted regressions and align changelog/version tracking under the `v0.7.0` release train

## Version Tracking
- tracked in `docs/FUTURE_PLAN.md` under the `v0.7.0` release target as carry-forward reliability scope
- added `CHANGELOG.md` `Unreleased` fixed entries for the shipped behavior corrections

## Verification
- `python3 -m ruff check backend/src/api/dashboard.py backend/src/api/security.py backend/src/main.py backend/tests/test_phase2_security.py backend/tests/test_storage_mode_selection.py`
- `python3 -m pytest backend/tests/test_storage_mode_selection.py backend/tests/test_phase2_security.py -q`
- `bash scripts/release_scope_check.sh`

## Notes
- this also backfills missing `CHANGELOG.md` references for the non-HEAD commits already landed since `v0.6.1` so the release-scope gate passes cleanly