### PR TITLE
docs: refresh stale release references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PipelineHealer
 
-<!-- LAST_VERIFIED: c183a90 -->
+<!-- LAST_VERIFIED: ac1b1ec -->
 
 > OSS-first, policy-aware pipeline remediation platform for failed delivery workflows.
 
@@ -47,7 +47,7 @@ Pipeline failures create repetitive triage work and slow delivery. PipelineHeale
 - Bridge path: Jenkins
 - Reference managed deployment: Azure Container Apps
 - Demo video: [YouTube walkthrough](https://youtu.be/9iv5ZMKYzts)
-- Latest published release: [`v0.6.1`](https://github.com/Canepro/pipelinehealer/releases/tag/v0.6.1)
+- Latest published release: [`v0.7.2`](https://github.com/Canepro/pipelinehealer/releases/tag/v0.7.2)
 - Detailed release history: [CHANGELOG.md](CHANGELOG.md)
 
 ## Jenkins Integration Kit
@@ -186,7 +186,7 @@ Important operator rule:
 - verify live model compatibility before demos or production promotion
 
 Validated Azure note:
-- as of `v0.6.0`, the strongest validated Azure path for `gpt-5.1-codex-mini` uses the `cognitiveservices.azure.com` base endpoint with the Responses-first runtime path
+- as of `v0.7.2`, the strongest validated Azure path for `gpt-5.1-codex-mini` uses the `cognitiveservices.azure.com` base endpoint with the Responses-first runtime path
 
 Detailed runtime contract: [docs/architecture/LLM_AND_AGENT_RUNTIME.md](docs/architecture/LLM_AND_AGENT_RUNTIME.md)
 

--- a/docs/HACKATHON_LOG.md
+++ b/docs/HACKATHON_LOG.md
@@ -1,8 +1,8 @@
 # PipelineHealer Hackathon Log
 
-<!-- LAST_VERIFIED: ec7e28f -->
+<!-- LAST_VERIFIED: ac1b1ec -->
 
-**Last updated:** March 12, 2026
+**Last updated:** March 15, 2026
 
 This is the long-form project tracker for hackathon execution status, submission readiness, and milestone history.
 
@@ -36,7 +36,7 @@ This is the long-form project tracker for hackathon execution status, submission
   - required scope locked to `#36/#42/#57` for submission reliability
   - `#58` (PostgreSQL adapter) was implemented only after required scope was complete, CI green, and docs synced
   - storage extensibility remained adapter-scoped (no core workflow rewrites during freeze)
-- Release `v0.6.1` is the current public baseline.
+- Release `v0.7.2` is the current public baseline.
 - `v0.5.8` shipped:
   - Settings and Control Center now distinguish configured, provider-ready, operation-compatible, full-capability, degraded, and scaffolded runtime states
 - `v0.5.9` shipped:
@@ -51,7 +51,13 @@ This is the long-form project tracker for hackathon execution status, submission
   - low-evidence Jenkins bridge incidents now read as context-first/unclassified instead of strong scored diagnostics
   - dashboard drill-down filters now work consistently from repository bars and failure-type pie slices
   - repository drill-down filtering is now resilient to repository-name casing mismatches
-- Post-`v0.6.1` follow-on work is continuity and release planning, not demo-scope product correction.
+- `v0.7.0` shipped:
+  - UI-first runtime configuration now persists non-secret settings directly from the product surface with setup-readiness visibility and write-only secret management
+  - operator workflows now expose stronger configuration provenance and runtime-boundary reporting for safe control-plane changes
+- `v0.7.2` shipped:
+  - release tooling and workflow guardrails were tightened so version metadata, changelog sections, and release tags stay aligned during publication
+  - release recovery documentation now reflects the post-`v0.7.1` correction path and current published baseline
+- Post-`v0.7.2` follow-on work is continuity and release planning, not demo-scope product correction.
 - Historical `v0.5.0` planning target is now shipped:
   - deployment-facing Assign-to-Agent receiver boundary
   - generic outbound event and notification routing

--- a/docs/architecture/LLM_AND_AGENT_RUNTIME.md
+++ b/docs/architecture/LLM_AND_AGENT_RUNTIME.md
@@ -1,6 +1,6 @@
 # LLM and Agent Runtime
 
-<!-- LAST_VERIFIED: c78ae9b -->
+<!-- LAST_VERIFIED: ac1b1ec -->
 
 This document is the operator-facing contract for how PipelineHealer uses LLMs and agents at runtime.
 
@@ -106,7 +106,7 @@ Practical interpretation:
 
 ## Validated Azure Behavior
 
-Validated on `v0.6.0`:
+Validated on `v0.7.2`:
 
 1. `https://<resource>.cognitiveservices.azure.com/`
 - `gpt-5.1-codex-mini`

--- a/docs/reference/API.md
+++ b/docs/reference/API.md
@@ -1,6 +1,6 @@
 # PipelineHealer API Reference
 
-<!-- LAST_VERIFIED: 4600984 -->
+<!-- LAST_VERIFIED: ac1b1ec -->
 
 This document describes the PipelineHealer backend REST API, authentication model, request/response contracts, and best practices.
 
@@ -88,7 +88,7 @@ Unauthenticated health check.
 ```json
 {
   "service": "PipelineHealer",
-  "version": "0.7.0",
+  "version": "0.7.2",
   "status": "healthy",
   "environment": "production",
   "storage_backend": "cosmos_db"

--- a/docs/runbooks/DEMO_SCRIPT.md
+++ b/docs/runbooks/DEMO_SCRIPT.md
@@ -1,6 +1,6 @@
 # PipelineHealer Demo Recording Guide (Single-File Runbook)
 
-<!-- LAST_VERIFIED: 83805e7 -->
+<!-- LAST_VERIFIED: ac1b1ec -->
 
 Use this as the only doc during recording day. It includes:
 
@@ -36,11 +36,11 @@ Remaining submission item this doc drives: demo video length must be 2:00 max.
 Default values used in this runbook:
 
 ```bash
-export RELEASE_TAG="${RELEASE_TAG:-$(git describe --tags --abbrev=0 2>/dev/null || echo v0.6.1)}"
+export RELEASE_TAG="${RELEASE_TAG:-$(git describe --tags --abbrev=0 2>/dev/null || echo v0.7.2)}"
 export DEMO_REPO="${DEMO_REPO:-Canepro/pipelinehealer-demo}"
 ```
 
-Keep `RELEASE_TAG` pinned to the latest published tag for recording. The default above resolves to the latest local tag when available and falls back to `v0.6.1` if tags have not been fetched yet. Do not point the demo flow at an untagged local branch or unreleased commit.
+Keep `RELEASE_TAG` pinned to the latest published tag for recording. The default above resolves to the latest local tag when available and falls back to `v0.7.2` if tags have not been fetched yet. Do not point the demo flow at an untagged local branch or unreleased commit.
 If `DEMO_REPO` is not exported in your shell, either run the export block above first or omit `--repo` and let `bash scripts/ph.sh demo:proof` fall back to the default demo repo.
 
 ## Recording Plan (2 Minutes Max)

--- a/docs/runbooks/LOCAL_DEMO_RUNBOOK.md
+++ b/docs/runbooks/LOCAL_DEMO_RUNBOOK.md
@@ -1,6 +1,6 @@
 # Local Demo Runbook (PipelineHealer)
 
-<!-- LAST_VERIFIED: 22efa6e -->
+<!-- LAST_VERIFIED: ac1b1ec -->
 
 This guide walks you through setting up PipelineHealer locally, triggering CI failures in a demo repo, and verifying the results on the dashboard.
 
@@ -123,7 +123,7 @@ In the Azure Portal, open your OpenAI resource page → **Keys and Endpoint**:
 
 > **Note:** If your endpoint uses the `cognitiveservices.azure.com` domain, that works too. PipelineHealer prefers the Azure Responses API first and falls back to Chat only when a deployment rejects Responses.
 
-Validated Azure combinations as of `v0.6.0`:
+Validated Azure combinations as of `v0.7.2`:
 - stable default path: `https://<resource>.openai.azure.com/` with `gpt-5-mini`
 - validated stronger diagnosis/remediation path: `https://<resource>.cognitiveservices.azure.com/` with `gpt-5.1-codex-mini`
 


### PR DESCRIPTION
## Summary
- refresh stale current-release references from v0.6.1/v0.6.0 to the current v0.7.2 baseline
- update demo and local runbooks so fallback/default release examples point at v0.7.2
- refresh LAST_VERIFIED markers for the edited user-facing docs

## Verification
- reviewed README and user-facing docs for stale current/latest/default release mentions
- confirmed repo version sync is 0.7.2 across VERSION, backend, frontend, and chart manifests
- confirmed no remaining docs still present v0.6.1, v0.6.0, or 0.7.0 as the current release state