### PR TITLE
test: make safe pytest wrapper capture-mode robust

### DIFF
--- a/docs/reference/CLI.md
+++ b/docs/reference/CLI.md
@@ -1,6 +1,6 @@
 # PipelineHealer CLI Reference
 
-<!-- LAST_VERIFIED: 39b33f24d -->
+<!-- LAST_VERIFIED: dbfc6bc -->
 
 Canonical reference for `scripts/ph.sh` — the one-command operator interface for PipelineHealer.
 

--- a/docs/reference/CLI.md
+++ b/docs/reference/CLI.md
@@ -1,6 +1,6 @@
 # PipelineHealer CLI Reference
 
-<!-- LAST_VERIFIED: c183a90 -->
+<!-- LAST_VERIFIED: 39b33f24d -->
 
 Canonical reference for `scripts/ph.sh` — the one-command operator interface for PipelineHealer.
 
@@ -445,12 +445,14 @@ Use the safe pytest wrapper to prevent indefinitely hanging test runs:
 ```bash
 bash scripts/pytest_safe.sh backend/tests/test_phase1_correctness.py -q
 PYTEST_TIMEOUT_SECONDS=2400 bash scripts/pytest_safe.sh backend/tests -q
+PYTEST_CAPTURE_MODE=no bash scripts/pytest_safe.sh backend/tests -q
 ```
 
 Defaults:
 
 - timeout: `1800s` (30 minutes)
 - graceful stop: `TERM`, then forced kill after 30s if needed
+- capture: `no` by default (`PYTEST_CAPTURE_MODE` can override)
 
 ### External Diagnostics
 

--- a/scripts/pytest_safe.sh
+++ b/scripts/pytest_safe.sh
@@ -7,11 +7,26 @@ set -euo pipefail
 #   PYTEST_TIMEOUT_SECONDS=2400 bash scripts/pytest_safe.sh backend/tests -q
 
 TIMEOUT_SECONDS="${PYTEST_TIMEOUT_SECONDS:-1800}" # 30 min default
+CAPTURE_MODE="${PYTEST_CAPTURE_MODE:-no}" # default to no capture to avoid pytest tmpfile errors in some WSL setups
+
+PYTEST_ARGS=("$@")
+HAS_CAPTURE_FLAG=false
+
+for arg in "${PYTEST_ARGS[@]}"; do
+  if [[ "$arg" == --capture* || "$arg" == -s ]]; then
+    HAS_CAPTURE_FLAG=true
+    break
+  fi
+done
+
+if [[ "$HAS_CAPTURE_FLAG" == false ]]; then
+  PYTEST_ARGS=(--capture="$CAPTURE_MODE" "${PYTEST_ARGS[@]}")
+fi
 
 if command -v timeout >/dev/null 2>&1; then
   exec timeout --foreground --signal=TERM --kill-after=30s "${TIMEOUT_SECONDS}s" \
-    python3 -m pytest "$@"
+    python3 -m pytest "${PYTEST_ARGS[@]}"
 fi
 
 echo "warning: 'timeout' command not found; running pytest without timeout guard" >&2
-exec python3 -m pytest "$@"
+exec python3 -m pytest "${PYTEST_ARGS[@]}"

--- a/scripts/pytest_safe.sh
+++ b/scripts/pytest_safe.sh
@@ -5,9 +5,23 @@ set -euo pipefail
 # Usage:
 #   bash scripts/pytest_safe.sh backend/tests -q
 #   PYTEST_TIMEOUT_SECONDS=2400 bash scripts/pytest_safe.sh backend/tests -q
+#   PYTEST_CAPTURE_MODE=no bash scripts/pytest_safe.sh backend/tests -q
+# Optional env overrides:
+#   PYTEST_TIMEOUT_SECONDS (default: 1800)
+#   PYTEST_CAPTURE_MODE (default: no)
 
 TIMEOUT_SECONDS="${PYTEST_TIMEOUT_SECONDS:-1800}" # 30 min default
 CAPTURE_MODE="${PYTEST_CAPTURE_MODE:-no}" # default to no capture to avoid pytest tmpfile errors in some WSL setups
+
+case "$CAPTURE_MODE" in
+  fd|sys|no|tee-sys)
+    ;;
+  *)
+    echo "error: invalid PYTEST_CAPTURE_MODE='$CAPTURE_MODE'" >&2
+    echo "supported values: fd, sys, no, tee-sys" >&2
+    exit 2
+    ;;
+esac
 
 PYTEST_ARGS=("$@")
 HAS_CAPTURE_FLAG=false


### PR DESCRIPTION
## Summary
- Hardened `scripts/pytest_safe.sh` to default pytest to capture mode `--capture=no` in environments where pytest's default `fd`/tmpfile capture mode crashes with `FileNotFoundError` on teardown.
- Added explicit opt-out/override by reusing existing command flags and a new `PYTEST_CAPTURE_MODE` env override for environments where caller wants default capture behavior.

## Verification
- `bash scripts/pytest_safe.sh backend/tests/test_jenkins_bridge_activity_semantics.py -q`
- `bash scripts/pytest_safe.sh backend/tests -q --maxfail=1`
