### PR TITLE
backend: make Azure client creation compatibility-safe

### DIFF
--- a/backend/src/agents/base.py
+++ b/backend/src/agents/base.py
@@ -372,12 +372,26 @@ def _create_azure_cloud_agent(
 
     # Use Responses API first for both classic Azure OpenAI and Azure AI Services
     # endpoints, then fall back to Chat when a deployment rejects Responses.
-    from agent_framework.azure import AzureOpenAIChatClient, AzureOpenAIResponsesClient
+    import agent_framework.azure as azure_clients
+
+    chat_client_cls = getattr(azure_clients, "AzureOpenAIChatClient", None)
+    if chat_client_cls is None:
+        raise RuntimeError(
+            "agent_framework.azure.AzureOpenAIChatClient is unavailable in this environment."
+        )
+
+    responses_client_cls = getattr(azure_clients, "AzureOpenAIResponsesClient", None)
+    if responses_client_cls is None:
+        logger.warning(
+            "agent_framework.azure.AzureOpenAIResponsesClient not available; "
+            "falling back to AzureOpenAIChatClient for primary path."
+        )
+        responses_client_cls = chat_client_cls
 
     # Primary version comes from AZURE_OPENAI_API_VERSION (env-driven).
     responses_api_version = api_version
 
-    responses_client: Any = AzureOpenAIResponsesClient(
+    responses_client: Any = responses_client_cls(
         endpoint=endpoint,
         deployment_name=resolved_deployment_name,
         api_version=responses_api_version,
@@ -389,7 +403,7 @@ def _create_azure_cloud_agent(
     # Compatibility fallback: certain resources/deployments may reject Responses API versions
     # while still supporting chat completions. Version from AZURE_OPENAI_CHAT_API_VERSION.
     fallback_chat_version = chat_api_version or api_version
-    fallback_chat_client: Any = AzureOpenAIChatClient(
+    fallback_chat_client: Any = chat_client_cls(
         endpoint=endpoint,
         deployment_name=resolved_deployment_name,
         api_version=fallback_chat_version,

--- a/backend/tests/test_azure_agent_factory.py
+++ b/backend/tests/test_azure_agent_factory.py
@@ -14,10 +14,12 @@ def test_cognitiveservices_endpoint_uses_responses_with_chat_fallback(monkeypatc
     monkeypatch.setattr(
         "agent_framework.azure.AzureOpenAIResponsesClient",
         _FakeResponsesClient,
+        raising=False,
     )
     monkeypatch.setattr(
         "agent_framework.azure.AzureOpenAIChatClient",
         _FakeChatClient,
+        raising=False,
     )
     monkeypatch.setattr(
         "src.agents.base._as_agent_compat",


### PR DESCRIPTION
## Summary
- Make Azure client creation resilient when `agent_framework.azure.AzureOpenAIResponsesClient` is unavailable (older Agent Framework package variants).
- Keep tests resilient by patching target symbols with `raising=False` so missing client symbols can still be injected for compatibility assertions.
- Preserve behavior by using `AzureOpenAIChatClient` as a safe primary fallback only when Responses symbol is missing.

## Verification
- `cd backend && python3 -m pytest --capture=no tests/test_azure_agent_factory.py -q`
- `cd backend && python3 -m pytest --capture=no -q tests`
