### PR TITLE
test: harden pytest wrapper capture handling

### DIFF
--- a/docs/reference/CLI.md
+++ b/docs/reference/CLI.md
@@ -1,6 +1,6 @@
 # PipelineHealer CLI Reference
 
-<!-- LAST_VERIFIED: c183a90 -->
+<!-- LAST_VERIFIED: c9520a1 -->
 
 Canonical reference for `scripts/ph.sh` — the one-command operator interface for PipelineHealer.
 
@@ -445,12 +445,14 @@ Use the safe pytest wrapper to prevent indefinitely hanging test runs:
 ```bash
 bash scripts/pytest_safe.sh backend/tests/test_phase1_correctness.py -q
 PYTEST_TIMEOUT_SECONDS=2400 bash scripts/pytest_safe.sh backend/tests -q
+PYTEST_CAPTURE_MODE=no bash scripts/pytest_safe.sh backend/tests -q
 ```
 
 Defaults:
 
 - timeout: `1800s` (30 minutes)
 - graceful stop: `TERM`, then forced kill after 30s if needed
+- capture: `no` by default (`PYTEST_CAPTURE_MODE` can override)
 
 ### External Diagnostics
 

--- a/scripts/pytest_safe.sh
+++ b/scripts/pytest_safe.sh
@@ -5,13 +5,42 @@ set -euo pipefail
 # Usage:
 #   bash scripts/pytest_safe.sh backend/tests -q
 #   PYTEST_TIMEOUT_SECONDS=2400 bash scripts/pytest_safe.sh backend/tests -q
+#   PYTEST_CAPTURE_MODE=no bash scripts/pytest_safe.sh backend/tests -q
+# Optional env overrides:
+#   PYTEST_TIMEOUT_SECONDS (default: 1800)
+#   PYTEST_CAPTURE_MODE (default: no)
 
 TIMEOUT_SECONDS="${PYTEST_TIMEOUT_SECONDS:-1800}" # 30 min default
+CAPTURE_MODE="${PYTEST_CAPTURE_MODE:-no}" # default to no capture to avoid pytest tmpfile errors in some WSL setups
+
+case "$CAPTURE_MODE" in
+  fd|sys|no|tee-sys)
+    ;;
+  *)
+    echo "error: invalid PYTEST_CAPTURE_MODE='$CAPTURE_MODE'" >&2
+    echo "supported values: fd, sys, no, tee-sys" >&2
+    exit 2
+    ;;
+esac
+
+PYTEST_ARGS=("$@")
+HAS_CAPTURE_FLAG=false
+
+for arg in "${PYTEST_ARGS[@]}"; do
+  if [[ "$arg" == --capture* || "$arg" == -s ]]; then
+    HAS_CAPTURE_FLAG=true
+    break
+  fi
+done
+
+if [[ "$HAS_CAPTURE_FLAG" == false ]]; then
+  PYTEST_ARGS=(--capture="$CAPTURE_MODE" "${PYTEST_ARGS[@]}")
+fi
 
 if command -v timeout >/dev/null 2>&1; then
   exec timeout --foreground --signal=TERM --kill-after=30s "${TIMEOUT_SECONDS}s" \
-    python3 -m pytest "$@"
+    python3 -m pytest "${PYTEST_ARGS[@]}"
 fi
 
 echo "warning: 'timeout' command not found; running pytest without timeout guard" >&2
-exec python3 -m pytest "$@"
+exec python3 -m pytest "${PYTEST_ARGS[@]}"


### PR DESCRIPTION
## Summary
- Harden `scripts/pytest_safe.sh` to avoid local WSL pytest teardown failures by defaulting to `--capture=no`.
- Add explicit `PYTEST_CAPTURE_MODE` support with validation (`fd`, `sys`, `no`, `tee-sys`).
- Keep explicit caller-provided capture flags (`--capture` / `-s`) untouched.
- Document capture behavior and environment overrides in `docs/reference/CLI.md`.

## Why
- In this environment, raw `pytest` invocation can fail with `FileNotFoundError` in `_pytest/capture.py` during teardown.

## Verification
- `bash scripts/pytest_safe.sh backend/tests/test_jenkins_bridge_activity_semantics.py -q`
- `bash scripts/pytest_safe.sh backend/tests -q --maxfail=1`
- `bash -n scripts/pytest_safe.sh`

Supersedes older open PR #163 and keeps scope limited to pytest wrapper reliability + docs.