### PR TITLE
fix: remove X-Admin-Key from Settings React Query cache keys

### DIFF
--- a/frontend/src/auth/settingsQueryAuthScope.test.ts
+++ b/frontend/src/auth/settingsQueryAuthScope.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getNextAdminKeyScopeId,
+  getSettingsQueryAuthScope,
+} from "./settingsQueryAuthScope";
+
+describe("settingsQueryAuthScope", () => {
+  it("separates session auth from admin-key auth without exposing the raw key", () => {
+    const adminSecret = "super-secret-admin-key";
+
+    const adminScope = getSettingsQueryAuthScope({
+      useSessionAuth: false,
+      adminKey: adminSecret,
+      adminKeyScopeId: 3,
+    });
+    const sessionScope = getSettingsQueryAuthScope({
+      useSessionAuth: true,
+      adminKey: adminSecret,
+      adminKeyScopeId: 3,
+    });
+
+    expect(adminScope).toBe("admin-key:3");
+    expect(sessionScope).toBe("session-auth");
+    expect(adminScope).not.toContain(adminSecret);
+    expect(sessionScope).not.toContain(adminSecret);
+  });
+
+  it("increments the opaque admin-key scope id for each loaded key", () => {
+    expect(getNextAdminKeyScopeId(null)).toBe(1);
+    expect(getNextAdminKeyScopeId(1)).toBe(2);
+    expect(getNextAdminKeyScopeId(7)).toBe(8);
+  });
+});

--- a/frontend/src/auth/settingsQueryAuthScope.ts
+++ b/frontend/src/auth/settingsQueryAuthScope.ts
@@ -1,0 +1,25 @@
+export function getSettingsQueryAuthScope({
+  useSessionAuth,
+  adminKey,
+  adminKeyScopeId,
+}: {
+  useSessionAuth: boolean;
+  adminKey: string;
+  adminKeyScopeId: number | null;
+}): string {
+  if (useSessionAuth) {
+    return "session-auth";
+  }
+
+  if (!adminKey) {
+    return "no-auth";
+  }
+
+  return `admin-key:${adminKeyScopeId ?? 0}`;
+}
+
+export function getNextAdminKeyScopeId(
+  current: number | null,
+): number {
+  return (current ?? 0) + 1;
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -9,6 +9,10 @@ import { detectCachedAdminSession } from "../auth/adminSession";
 import { useApiAuthReady } from "../auth/apiAuthReady";
 import { AUTH_ENABLED } from "../auth/config";
 import {
+  getNextAdminKeyScopeId,
+  getSettingsQueryAuthScope,
+} from "../auth/settingsQueryAuthScope";
+import {
   AdminControlsForm,
   RuntimePolicyBanner,
   toSettingsForm,
@@ -30,6 +34,7 @@ export default function SettingsPage() {
   const isApiAuthReady = useApiAuthReady();
   const [adminKeyInput, setAdminKeyInput] = useState("");
   const [adminKey, setAdminKey] = useState("");
+  const [adminKeyScopeId, setAdminKeyScopeId] = useState<number | null>(null);
   const [useSessionAuth, setUseSessionAuth] = useState(false);
   const [newMcpRepoInput, setNewMcpRepoInput] = useState("");
   const [newHandoffHostInput, setNewHandoffHostInput] = useState("");
@@ -97,30 +102,49 @@ export default function SettingsPage() {
   const hasAuthAttempt =
     adminKey.length > 0 || (isApiAuthReady && useSessionAuth);
   const effectiveAdminKey = useSessionAuth ? undefined : adminKey;
+  const authQueryScope = getSettingsQueryAuthScope({
+    useSessionAuth,
+    adminKey,
+    adminKeyScopeId,
+  });
+  const settingsQueryKey = ["app-settings", authQueryScope] as const;
+  const secretSettingsQueryKey = ["secret-settings", authQueryScope] as const;
+  const llmProviderHealthQueryKey = [
+    "llm-provider-health",
+    authQueryScope,
+  ] as const;
+  const mcpProviderHealthQueryKey = [
+    "mcp-provider-health",
+    authQueryScope,
+  ] as const;
+  const handoffIntegrationStatusQueryKey = [
+    "agent-handoff-integration-status",
+    authQueryScope,
+  ] as const;
 
   const { data, isLoading, isError, error } = useQuery({
-    queryKey: ["app-settings", adminKey, useSessionAuth],
+    queryKey: settingsQueryKey,
     queryFn: () => api.getSettings(effectiveAdminKey),
     enabled: hasAuthAttempt,
     retry: false,
   });
 
   const { data: secretSettings } = useQuery({
-    queryKey: ["secret-settings", adminKey, useSessionAuth],
+    queryKey: secretSettingsQueryKey,
     queryFn: () => api.getSecretSettings(effectiveAdminKey),
     enabled: hasAuthAttempt,
     retry: false,
   });
 
   const { data: llmProviderHealth, isLoading: isLlmHealthLoading } = useQuery({
-    queryKey: ["llm-provider-health", adminKey, useSessionAuth],
+    queryKey: llmProviderHealthQueryKey,
     queryFn: () => api.getLLMProviderHealth(effectiveAdminKey),
     enabled: hasAuthAttempt,
     retry: false,
   });
 
   const { data: mcpProviderHealth, isLoading: isMcpHealthLoading } = useQuery({
-    queryKey: ["mcp-provider-health", adminKey, useSessionAuth],
+    queryKey: mcpProviderHealthQueryKey,
     queryFn: () => api.getMCPProviderHealth(effectiveAdminKey),
     enabled: hasAuthAttempt,
     retry: false,
@@ -131,7 +155,7 @@ export default function SettingsPage() {
     isError: isHandoffIntegrationError,
     error: handoffIntegrationError,
   } = useQuery({
-    queryKey: ["agent-handoff-integration-status", hasAuthAttempt],
+    queryKey: handoffIntegrationStatusQueryKey,
     queryFn: () => api.getAgentHandoffIntegrationStatus(),
     enabled: hasAuthAttempt,
     retry: false,
@@ -247,12 +271,9 @@ export default function SettingsPage() {
       setForm(next);
       setLastSavedForm(next);
       setGhAwWorkflowsInput(next.gh_aw_known_workflows.join(","));
-      queryClient.setQueryData(
-        ["app-settings", adminKey, useSessionAuth],
-        updated,
-      );
+      queryClient.setQueryData(settingsQueryKey, updated);
       await queryClient.invalidateQueries({
-        queryKey: ["app-settings", adminKey, useSessionAuth],
+        queryKey: settingsQueryKey,
       });
       toast.success("Settings saved", {
         description: "Changes are active now and persisted for future restarts unless overridden by env.",
@@ -281,10 +302,12 @@ export default function SettingsPage() {
         return next;
       });
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ["secret-settings", adminKey, useSessionAuth] }),
-        queryClient.invalidateQueries({ queryKey: ["app-settings", adminKey, useSessionAuth] }),
-        queryClient.invalidateQueries({ queryKey: ["llm-provider-health", adminKey, useSessionAuth] }),
-        queryClient.invalidateQueries({ queryKey: ["agent-handoff-integration-status", hasAuthAttempt] }),
+        queryClient.invalidateQueries({ queryKey: secretSettingsQueryKey }),
+        queryClient.invalidateQueries({ queryKey: settingsQueryKey }),
+        queryClient.invalidateQueries({ queryKey: llmProviderHealthQueryKey }),
+        queryClient.invalidateQueries({
+          queryKey: handoffIntegrationStatusQueryKey,
+        }),
       ]);
       toast.success("Secret updated", {
         description: "The value was stored without being returned to the UI.",
@@ -346,6 +369,7 @@ export default function SettingsPage() {
     }
     setUseSessionAuth(false);
     setAdminKey(trimmed);
+    setAdminKeyScopeId((current) => getNextAdminKeyScopeId(current));
     setAdminKeyInput("");
   };
 


### PR DESCRIPTION
## Summary
- remove raw admin-key material from Settings page React Query keys
- introduce a non-secret auth-scope helper for Settings queries and invalidation
- add regression coverage for scoped query-key behavior

## Why
The Settings page was embedding raw `X-Admin-Key` values in client-side query keys, which exposes secret material in devtools-visible cache metadata and similar debugging surfaces.

## Implementation
- session-auth flow now keys as `session-auth`
- admin-key flow now keys as an opaque `admin-key:<counter>` scope
- Settings invalidation and `setQueryData` now use the same safe scoped keys
- handoff integration status on Settings was aligned to the same scoped-key pattern for consistency

## Validation
- `npx vitest run src/auth/settingsQueryAuthScope.test.ts`
- `npx eslint src/pages/Settings.tsx src/auth/settingsQueryAuthScope.ts src/auth/settingsQueryAuthScope.test.ts`

## Notes

- follow-up likely needed for the same raw-admin-key query-key pattern in `frontend/src/pages/ControlCenter.tsx`

Closes #158