### PR TITLE
draft: review batch 1

### DIFF
--- a/frontend/src/auth/settingsQueryAuthScope.test.ts
+++ b/frontend/src/auth/settingsQueryAuthScope.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getNextAdminKeyScopeId,
+  getSettingsQueryAuthScope,
+} from "./settingsQueryAuthScope";
+
+describe("settingsQueryAuthScope", () => {
+  it("separates session auth from admin-key auth without exposing the raw key", () => {
+    const adminSecret = "super-secret-admin-key";
+
+    const adminScope = getSettingsQueryAuthScope({
+      useSessionAuth: false,
+      adminKey: adminSecret,
+      adminKeyScopeId: 3,
+    });
+    const sessionScope = getSettingsQueryAuthScope({
+      useSessionAuth: true,
+      adminKey: adminSecret,
+      adminKeyScopeId: 3,
+    });
+
+    expect(adminScope).toBe("admin-key:3");
+    expect(sessionScope).toBe("session-auth");
+    expect(adminScope).not.toContain(adminSecret);
+    expect(sessionScope).not.toContain(adminSecret);
+  });
+
+  it("increments the opaque admin-key scope id for each loaded key", () => {
+    expect(getNextAdminKeyScopeId(null)).toBe(1);
+    expect(getNextAdminKeyScopeId(1)).toBe(2);
+    expect(getNextAdminKeyScopeId(7)).toBe(8);
+  });
+});

--- a/frontend/src/auth/settingsQueryAuthScope.ts
+++ b/frontend/src/auth/settingsQueryAuthScope.ts
@@ -1,0 +1,25 @@
+export function getSettingsQueryAuthScope({
+  useSessionAuth,
+  adminKey,
+  adminKeyScopeId,
+}: {
+  useSessionAuth: boolean;
+  adminKey: string;
+  adminKeyScopeId: number | null;
+}): string {
+  if (useSessionAuth) {
+    return "session-auth";
+  }
+
+  if (!adminKey) {
+    return "no-auth";
+  }
+
+  return `admin-key:${adminKeyScopeId ?? 0}`;
+}
+
+export function getNextAdminKeyScopeId(
+  current: number | null,
+): number {
+  return (current ?? 0) + 1;
+}

--- a/frontend/src/components/settings/AdminControlsForm.tsx
+++ b/frontend/src/components/settings/AdminControlsForm.tsx
@@ -1,4 +1,4 @@
-import { useState, type Dispatch, type SetStateAction } from "react";
+import { useId, useState, type Dispatch, type SetStateAction } from "react";
 import {
   ChevronDown,
   Copy,
@@ -58,7 +58,6 @@ import {
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Tooltip,
   TooltipContent,
@@ -99,6 +98,77 @@ interface Props {
 }
 
 type SettingsSection = "runtime" | "intelligence" | "security";
+
+const SETTINGS_SECTION_OPTIONS: Array<{
+  value: SettingsSection;
+  label: string;
+  summary: string;
+  Icon: typeof Zap;
+}> = [
+  {
+    value: "runtime",
+    label: "1. Runtime Controls",
+    summary:
+      "Runtime Controls: set remediation behavior, repo scope, and operation mode first.",
+    Icon: Zap,
+  },
+  {
+    value: "intelligence",
+    label: "2. AI & Integrations",
+    summary:
+      "AI & Integrations: configure model providers, handoff, external diagnostics, and MCP policies.",
+    Icon: Sparkles,
+  },
+  {
+    value: "security",
+    label: "3. Security & Advanced",
+    summary:
+      "Security & Advanced: adjust auth posture, retries, limits, and low-level safeguards.",
+    Icon: Shield,
+  },
+];
+
+export function SettingsSectionSwitcher({
+  activeSection,
+  onChange,
+}: {
+  activeSection: SettingsSection;
+  onChange: (section: SettingsSection) => void;
+}) {
+  const activeOption =
+    SETTINGS_SECTION_OPTIONS.find((option) => option.value === activeSection) ??
+    SETTINGS_SECTION_OPTIONS[0];
+
+  return (
+    <>
+      <nav aria-label="Settings sections">
+        <ul className="grid h-auto list-none grid-cols-1 gap-4 p-0 sm:grid-cols-3">
+          {SETTINGS_SECTION_OPTIONS.map(({ value, label, Icon }) => {
+            const isActive = value === activeSection;
+            return (
+              <li key={value}>
+                <Button
+                  type="button"
+                  variant={isActive ? "secondary" : "ghost"}
+                  className="w-full justify-center gap-2 py-3 text-sm font-semibold"
+                  aria-pressed={isActive}
+                  id={`settings-section-trigger-${value}`}
+                  onClick={() => onChange(value)}
+                >
+                  <Icon className="h-4 w-4" />
+                  {label}
+                </Button>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+      <p className="mt-3 text-sm text-[var(--ph-muted)]">
+        {activeOption.summary}
+      </p>
+    </>
+  );
+}
 type NotificationTargetType =
   | "email"
   | "webhook"
@@ -649,45 +719,10 @@ export default function AdminControlsForm({
       <div className="space-y-8">
         <Card>
           <CardContent className="py-5">
-            <Tabs
-              value={activeSection}
-              onValueChange={(value) =>
-                setActiveSection(value as SettingsSection)
-              }
-              className="w-full"
-            >
-              <TabsList className="grid h-auto w-full grid-cols-1 gap-4 sm:grid-cols-3">
-                <TabsTrigger
-                  value="runtime"
-                  className="flex items-center justify-center gap-2 py-3 text-sm font-semibold"
-                >
-                  <Zap className="h-4 w-4" />
-                  1. Runtime Controls
-                </TabsTrigger>
-                <TabsTrigger
-                  value="intelligence"
-                  className="flex items-center justify-center gap-2 py-3 text-sm font-semibold"
-                >
-                  <Sparkles className="h-4 w-4" />
-                  2. AI & Integrations
-                </TabsTrigger>
-                <TabsTrigger
-                  value="security"
-                  className="flex items-center justify-center gap-2 py-3 text-sm font-semibold"
-                >
-                  <Shield className="h-4 w-4" />
-                  3. Security & Advanced
-                </TabsTrigger>
-              </TabsList>
-            </Tabs>
-            <p className="mt-3 text-sm text-[var(--ph-muted)]">
-              {activeSection === "runtime" &&
-                "Runtime Controls: set remediation behavior, repo scope, and operation mode first."}
-              {activeSection === "intelligence" &&
-                "AI & Integrations: configure model providers, handoff, external diagnostics, and MCP policies."}
-              {activeSection === "security" &&
-                "Security & Advanced: adjust auth posture, retries, limits, and low-level safeguards."}
-            </p>
+            <SettingsSectionSwitcher
+              activeSection={activeSection}
+              onChange={setActiveSection}
+            />
           </CardContent>
         </Card>
 
@@ -2912,7 +2947,7 @@ function FieldGroup({
   );
 }
 
-function SwitchField({
+export function SwitchField({
   label,
   field,
   checked,
@@ -2927,15 +2962,21 @@ function SwitchField({
 }) {
   const desc = SETTING_DESCRIPTIONS[field];
   const durability = getDurabilityLabel(metadata);
+  const switchId = useId();
+  const descriptionId = desc ? `${switchId}-description` : undefined;
+
   return (
     <div className="flex items-start gap-3 py-1">
-      <Switch checked={checked} onCheckedChange={onChange} className="mt-0.5" />
+      <Switch
+        id={switchId}
+        checked={checked}
+        onCheckedChange={onChange}
+        className="mt-0.5"
+        aria-describedby={descriptionId}
+      />
       <div>
         <div className="flex flex-wrap items-center gap-1.5">
-          <Label
-            className="text-[var(--ph-text)] cursor-pointer"
-            onClick={() => onChange(!checked)}
-          >
+          <Label htmlFor={switchId} className="text-[var(--ph-text)] cursor-pointer">
             {label}
           </Label>
           {metadata && (
@@ -2950,7 +2991,9 @@ function SwitchField({
           )}
         </div>
         {desc && (
-          <p className="text-xs text-[var(--ph-muted)] mt-0.5">{desc}</p>
+          <p id={descriptionId} className="text-xs text-[var(--ph-muted)] mt-0.5">
+            {desc}
+          </p>
         )}
       </div>
     </div>

--- a/frontend/src/components/settings/AdminControlsForm.tsx
+++ b/frontend/src/components/settings/AdminControlsForm.tsx
@@ -28,6 +28,8 @@ import {
 } from "./types";
 import {
   describeLlmCapability,
+  describeLlmHealthFailure,
+  describeMcpHealthFailure,
   formatLlmValidationLabel,
   formatSettingSource,
   getDurabilityLabel,
@@ -70,8 +72,12 @@ interface Props {
   setForm: Dispatch<SetStateAction<SettingsFormState>>;
   llmProviderHealth?: LLMProviderHealth;
   isLlmHealthLoading?: boolean;
+  isLlmHealthError?: boolean;
+  llmHealthError?: Error | null;
   mcpProviderHealth?: MCPProviderHealth;
   isMcpHealthLoading?: boolean;
+  isMcpHealthError?: boolean;
+  mcpHealthError?: Error | null;
   llmCapabilitySummary?: {
     summary: string;
     detail: string;
@@ -368,8 +374,12 @@ export default function AdminControlsForm({
   setForm,
   llmProviderHealth,
   isLlmHealthLoading,
+  isLlmHealthError,
+  llmHealthError,
   mcpProviderHealth,
   isMcpHealthLoading,
+  isMcpHealthError,
+  mcpHealthError,
   llmCapabilitySummary,
   hasUnsavedChanges,
   newRepoInput,
@@ -435,6 +445,12 @@ export default function AdminControlsForm({
   const resolvedLlmCapability =
     llmCapabilitySummary ?? describeLlmCapability(llmProviderHealth);
   const llmValidationLabel = formatLlmValidationLabel(llmProviderHealth);
+  const llmHealthFailure = isLlmHealthError
+    ? describeLlmHealthFailure(llmHealthError)
+    : null;
+  const mcpHealthFailure = isMcpHealthError
+    ? describeMcpHealthFailure(mcpHealthError)
+    : null;
   const taskModelPreview = [
     {
       key: "analysis",
@@ -1339,15 +1355,21 @@ export default function AdminControlsForm({
                   value={
                     isLlmHealthLoading
                       ? "Checking..."
+                      : isLlmHealthError
+                        ? "Request failed"
                       : llmProviderHealth
                         ? `${llmProviderHealth.available ? "Available" : "Unavailable"} (${llmProviderHealth.reason})`
                         : "Unavailable"
                   }
+                  description={llmHealthFailure?.detail}
+                  guidance={llmHealthFailure?.guidance}
                 />
                 <ReadOnlyField
                   label="Provider Status"
                   value={
-                    llmProviderHealth
+                    isLlmHealthError
+                      ? "Unknown"
+                      : llmProviderHealth
                       ? llmProviderHealth.implemented
                         ? "Implemented"
                         : "Scaffolded only"
@@ -1359,20 +1381,32 @@ export default function AdminControlsForm({
                   value={
                     isLlmHealthLoading
                       ? "Checking..."
+                      : isLlmHealthError
+                        ? "Request failed"
                       : resolvedLlmCapability.summary
                   }
+                  description={llmHealthFailure?.detail}
+                  guidance={llmHealthFailure?.guidance}
                 />
                 <ReadOnlyField
                   label="Last validation"
                   value={
-                    isLlmHealthLoading ? "Checking..." : llmValidationLabel
+                    isLlmHealthLoading
+                      ? "Checking..."
+                      : isLlmHealthError
+                        ? "Unavailable"
+                        : llmValidationLabel
                   }
+                  description={llmHealthFailure?.detail}
+                  guidance={llmHealthFailure?.guidance}
                 />
               </div>
               <p className="text-xs text-[var(--ph-muted)]">
                 {isLlmHealthLoading
                   ? "Checking recent live LLM capability evidence..."
-                  : resolvedLlmCapability.detail}
+                  : isLlmHealthError
+                    ? `${llmHealthFailure?.detail} ${llmHealthFailure?.guidance}`
+                    : resolvedLlmCapability.detail}
               </p>
               <Separator />
               <div className="space-y-3">
@@ -1958,10 +1992,14 @@ export default function AdminControlsForm({
                   value={
                     isMcpHealthLoading
                       ? "Checking..."
+                      : isMcpHealthError
+                        ? "Probe failed"
                       : mcpProviderHealth
                         ? `${mcpProviderHealth.available ? "Available" : "Unavailable"} (${mcpProviderHealth.reason})`
                         : "Unavailable"
                   }
+                  description={mcpHealthFailure?.detail}
+                  guidance={mcpHealthFailure?.guidance}
                 />
               </div>
               <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
@@ -2922,10 +2960,14 @@ function SwitchField({
 function ReadOnlyField({
   label,
   value,
+  description,
+  guidance,
   metadata,
 }: {
   label: string;
   value: string | number;
+  description?: string;
+  guidance?: string;
   metadata?: AppSettingMetadata;
 }) {
   const durability = getDurabilityLabel(metadata);
@@ -2950,6 +2992,12 @@ function ReadOnlyField({
           <span className="text-[var(--ph-muted)] italic">Not set</span>
         )}
       </p>
+      {description ? (
+        <p className="text-xs text-[var(--ph-muted)]">{description}</p>
+      ) : null}
+      {guidance ? (
+        <p className="text-xs text-[var(--ph-muted)]">{guidance}</p>
+      ) : null}
       {metadata?.note ? (
         <p className="text-xs text-[var(--ph-muted)]">{metadata.note}</p>
       ) : null}

--- a/frontend/src/components/settings/SettingToggleField.tsx
+++ b/frontend/src/components/settings/SettingToggleField.tsx
@@ -23,6 +23,8 @@ export function SettingToggleField({
 }) {
   const switchId = useId();
   const descriptionId = `${switchId}-description`;
+  const stateId = `${switchId}-state`;
+  const stateLabel = checked ? checkedLabel : uncheckedLabel;
 
   return (
     <div className="space-y-3">
@@ -48,14 +50,16 @@ export function SettingToggleField({
           id={switchId}
           checked={checked}
           onCheckedChange={onChange}
-          aria-describedby={descriptionId}
+          aria-describedby={`${descriptionId} ${stateId}`}
         />
-        <Label
-          htmlFor={switchId}
-          className="cursor-pointer text-sm text-[var(--ph-text)]"
+        <span
+          id={stateId}
+          aria-live="polite"
+          className="text-sm text-[var(--ph-text)]"
         >
-          {checked ? checkedLabel : uncheckedLabel}
-        </Label>
+          <span className="sr-only">Current state: </span>
+          {stateLabel}
+        </span>
       </div>
     </div>
   );

--- a/frontend/src/components/settings/SettingToggleField.tsx
+++ b/frontend/src/components/settings/SettingToggleField.tsx
@@ -1,0 +1,62 @@
+import { useId } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+
+export function SettingToggleField({
+  label,
+  description,
+  checked,
+  checkedLabel,
+  uncheckedLabel,
+  badgeLabel,
+  onChange,
+}: {
+  label: string;
+  description: string;
+  checked: boolean;
+  checkedLabel: string;
+  uncheckedLabel: string;
+  badgeLabel: string;
+  onChange: (value: boolean) => void;
+}) {
+  const switchId = useId();
+  const descriptionId = `${switchId}-description`;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <Label
+            htmlFor={switchId}
+            className="cursor-pointer text-sm font-medium text-[var(--ph-text)]"
+          >
+            {label}
+          </Label>
+          <p
+            id={descriptionId}
+            className="mt-1 text-xs leading-5 text-[var(--ph-muted)]"
+          >
+            {description}
+          </p>
+        </div>
+        <Badge variant="outline">{badgeLabel}</Badge>
+      </div>
+      <div className="flex items-center gap-3">
+        <Switch
+          id={switchId}
+          checked={checked}
+          onCheckedChange={onChange}
+          aria-describedby={descriptionId}
+        />
+        <Label
+          htmlFor={switchId}
+          className="cursor-pointer text-sm text-[var(--ph-text)]"
+        >
+          {checked ? checkedLabel : uncheckedLabel}
+        </Label>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/runtimeSemantics.test.ts
+++ b/frontend/src/components/settings/runtimeSemantics.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  describeLlmHealthFailure,
+  describeMcpHealthFailure,
+  describeSecretSettingsFailure,
+  formatIntegrationQueryState,
+} from "./runtimeSemantics";
+
+describe("runtimeSemantics subquery failures", () => {
+  it("surfaces explicit secret settings failures with retry guidance", () => {
+    expect(describeSecretSettingsFailure(new Error("401 Unauthorized"))).toEqual({
+      title: "Secret settings request failed",
+      detail: "401 Unauthorized",
+      guidance:
+        "Check the active auth method and secret backend configuration, then retry.",
+    });
+  });
+
+  it("falls back to a stable LLM failure message when the error is absent", () => {
+    expect(describeLlmHealthFailure()).toEqual({
+      title: "LLM health request failed",
+      detail: "LLM health request failed.",
+      guidance:
+        "Check the active auth method and LLM provider health configuration, then retry.",
+    });
+  });
+
+  it("preserves MCP probe failure detail instead of collapsing to unavailable", () => {
+    expect(describeMcpHealthFailure(new Error("gateway timeout"))).toEqual({
+      title: "MCP health request failed",
+      detail: "gateway timeout",
+      guidance:
+        "Check the active auth method and MCP provider health configuration, then retry.",
+    });
+  });
+
+  it("keeps integration probe failures distinct from normal unavailable states", () => {
+    expect(
+      formatIntegrationQueryState({
+        isError: true,
+        error: new Error("invalid bearer token"),
+      }),
+    ).toEqual({
+      summary: "Probe failed",
+      detail: "invalid bearer token",
+      tone: "bad",
+    });
+  });
+});

--- a/frontend/src/components/settings/runtimeSemantics.ts
+++ b/frontend/src/components/settings/runtimeSemantics.ts
@@ -16,6 +16,62 @@ export type McpEffectiveState = {
 
 export type IntegrationTone = 'ok' | 'warn' | 'bad' | 'muted'
 
+export type SubqueryFailureState = {
+  title: string
+  detail: string
+  guidance: string
+}
+
+function formatSubqueryFailure(args: {
+  title: string
+  fallbackDetail: string
+  guidance: string
+  error?: Error | null
+}): SubqueryFailureState {
+  const detail = args.error?.message?.trim() || args.fallbackDetail
+  return {
+    title: args.title,
+    detail,
+    guidance: args.guidance,
+  }
+}
+
+export function describeSecretSettingsFailure(
+  error?: Error | null
+): SubqueryFailureState {
+  return formatSubqueryFailure({
+    title: 'Secret settings request failed',
+    fallbackDetail: 'Secrets request failed.',
+    guidance:
+      'Check the active auth method and secret backend configuration, then retry.',
+    error,
+  })
+}
+
+export function describeLlmHealthFailure(
+  error?: Error | null
+): SubqueryFailureState {
+  return formatSubqueryFailure({
+    title: 'LLM health request failed',
+    fallbackDetail: 'LLM health request failed.',
+    guidance:
+      'Check the active auth method and LLM provider health configuration, then retry.',
+    error,
+  })
+}
+
+export function describeMcpHealthFailure(
+  error?: Error | null
+): SubqueryFailureState {
+  return formatSubqueryFailure({
+    title: 'MCP health request failed',
+    fallbackDetail: 'MCP health request failed.',
+    guidance:
+      'Check the active auth method and MCP provider health configuration, then retry.',
+    error,
+  })
+}
+
 export function describeLlmCapability(
   health?: LLMProviderHealth
 ): { summary: string; detail: string; tone: IntegrationTone } {

--- a/frontend/src/components/settings/settingsAccessibility.test.tsx
+++ b/frontend/src/components/settings/settingsAccessibility.test.tsx
@@ -1,0 +1,61 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { SettingToggleField } from "./SettingToggleField";
+import { SettingsSectionSwitcher, SwitchField } from "./AdminControlsForm";
+
+describe("Settings accessibility smoke checks", () => {
+  it("renders the section switcher as a labelled pressed-button navigation control", () => {
+    const markup = renderToStaticMarkup(
+      <SettingsSectionSwitcher
+        activeSection="security"
+        onChange={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain('aria-label="Settings sections"');
+    expect(markup).toContain('id="settings-section-trigger-security"');
+    expect(markup).toContain('aria-pressed="true"');
+  });
+
+  it("associates admin switch labels and descriptions with the switch control", () => {
+    const markup = renderToStaticMarkup(
+      <SwitchField
+        label="Retry failed workflows"
+        field="auto_retry_workflow"
+        checked
+        onChange={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain('role="switch"');
+    expect(markup).toMatch(
+      /role="switch"[\s\S]*id=(?:"|')?([^"'> ]+)(?:"|')?[\s\S]*<label[^>]*for=(?:"|')?\1(?:"|')?[^>]*>Retry failed workflows<\/label>/,
+    );
+    expect(markup).toMatch(
+      /role="switch"[\s\S]*aria-describedby=(?:"|')?([^"'> ]+)(?:"|')?[\s\S]*<p id=(?:"|')?\1(?:"|')?[\s\S]*Allows PipelineHealer to trigger retry of failed workflow jobs/,
+    );
+  });
+
+  it("associates runtime wiring toggles with the switch control and visible state label", () => {
+    const markup = renderToStaticMarkup(
+      <SettingToggleField
+        label="Verify webhook signatures"
+        description="Keep this enabled in production."
+        checked
+        checkedLabel="Required"
+        uncheckedLabel="Disabled"
+        badgeLabel="Runtime"
+        onChange={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain('role="switch"');
+    expect(markup).toMatch(
+      /<label[^>]*for=(?:"|')?([^"'> ]+)(?:"|')?[^>]*>Verify webhook signatures<\/label>[\s\S]*role="switch"[\s\S]*id=(?:"|')?\1(?:"|')?/,
+    );
+    expect(markup).toMatch(
+      /<label[^>]*for=(?:"|')?([^"'> ]+)(?:"|')?[^>]*>Required<\/label>[\s\S]*$/,
+    );
+  });
+});

--- a/frontend/src/components/settings/settingsAccessibility.test.tsx
+++ b/frontend/src/components/settings/settingsAccessibility.test.tsx
@@ -4,6 +4,26 @@ import { describe, expect, it } from "vitest";
 import { SettingToggleField } from "./SettingToggleField";
 import { SettingsSectionSwitcher, SwitchField } from "./AdminControlsForm";
 
+function escapeRegex(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function getSwitchId(markup: string) {
+  const match = markup.match(
+    /role="switch"[\s\S]*?id=(?:"|')?([^"'> ]+)(?:"|')?/,
+  );
+  expect(match).not.toBeNull();
+  return match?.[1] ?? "";
+}
+
+function getSwitchDescribedByIds(markup: string) {
+  const match = markup.match(
+    /role="switch"[\s\S]*?aria-describedby=(?:"|')?([^"'>]+)(?:"|')?/,
+  );
+  expect(match).not.toBeNull();
+  return (match?.[1] ?? "").split(/\s+/).filter(Boolean);
+}
+
 describe("Settings accessibility smoke checks", () => {
   it("renders the section switcher as a labelled pressed-button navigation control", () => {
     const markup = renderToStaticMarkup(
@@ -28,16 +48,24 @@ describe("Settings accessibility smoke checks", () => {
       />,
     );
 
+    const switchId = getSwitchId(markup);
+    const describedByIds = getSwitchDescribedByIds(markup);
+
     expect(markup).toContain('role="switch"');
     expect(markup).toMatch(
-      /role="switch"[\s\S]*id=(?:"|')?([^"'> ]+)(?:"|')?[\s\S]*<label[^>]*for=(?:"|')?\1(?:"|')?[^>]*>Retry failed workflows<\/label>/,
+      new RegExp(
+        `<label[^>]*for=(?:"|')?${escapeRegex(switchId)}(?:"|')?[^>]*>Retry failed workflows<\\/label>`,
+      ),
     );
+    expect(describedByIds).toHaveLength(1);
     expect(markup).toMatch(
-      /role="switch"[\s\S]*aria-describedby=(?:"|')?([^"'> ]+)(?:"|')?[\s\S]*<p id=(?:"|')?\1(?:"|')?[\s\S]*Allows PipelineHealer to trigger retry of failed workflow jobs/,
+      new RegExp(
+        `<p id=(?:"|')?${escapeRegex(describedByIds[0])}(?:"|')?[^>]*>`,
+      ),
     );
   });
 
-  it("associates runtime wiring toggles with the switch control and visible state label", () => {
+  it("associates runtime wiring toggles with one label, descriptive help text, and state text", () => {
     const markup = renderToStaticMarkup(
       <SettingToggleField
         label="Verify webhook signatures"
@@ -50,12 +78,32 @@ describe("Settings accessibility smoke checks", () => {
       />,
     );
 
+    const switchId = getSwitchId(markup);
+    const describedByIds = getSwitchDescribedByIds(markup);
+    const labelsForSwitch = markup.match(
+      new RegExp(
+        `<label[^>]*for=(?:"|')?${escapeRegex(switchId)}(?:"|')?`,
+        "g",
+      ),
+    );
+
     expect(markup).toContain('role="switch"');
+    expect(labelsForSwitch).toHaveLength(1);
     expect(markup).toMatch(
-      /<label[^>]*for=(?:"|')?([^"'> ]+)(?:"|')?[^>]*>Verify webhook signatures<\/label>[\s\S]*role="switch"[\s\S]*id=(?:"|')?\1(?:"|')?/,
+      new RegExp(
+        `<label[^>]*for=(?:"|')?${escapeRegex(switchId)}(?:"|')?[^>]*>Verify webhook signatures<\\/label>`,
+      ),
+    );
+    expect(describedByIds).toHaveLength(2);
+    expect(markup).toMatch(
+      new RegExp(
+        `<p id=(?:"|')?${escapeRegex(describedByIds[0])}(?:"|')?[^>]*>`,
+      ),
     );
     expect(markup).toMatch(
-      /<label[^>]*for=(?:"|')?([^"'> ]+)(?:"|')?[^>]*>Required<\/label>[\s\S]*$/,
+      new RegExp(
+        `<span id=(?:"|')?${escapeRegex(describedByIds[1])}(?:"|')?[^>]*aria-live="polite"`,
+      ),
     );
   });
 });

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -327,6 +327,7 @@ export default function SettingsPage() {
         queryClient.invalidateQueries({ queryKey: secretSettingsQueryKey }),
         queryClient.invalidateQueries({ queryKey: settingsQueryKey }),
         queryClient.invalidateQueries({ queryKey: llmProviderHealthQueryKey }),
+        queryClient.invalidateQueries({ queryKey: mcpProviderHealthQueryKey }),
         queryClient.invalidateQueries({
           queryKey: handoffIntegrationStatusQueryKey,
         }),

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -22,6 +22,7 @@ import {
   describeLlmCapability,
   describeSecretSettingsFailure,
   formatIntegrationQueryState,
+  type SubqueryFailureState,
 } from "../components/settings/runtimeSemantics";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -1115,11 +1116,7 @@ function SecretSettingsCard({
   pendingKey,
 }: {
   secrets: SecretSetting[];
-  errorState?: {
-    title: string;
-    detail: string;
-    guidance: string;
-  } | null;
+  errorState?: SubqueryFailureState | null;
   values: Record<string, string>;
   onChange: (key: string, value: string) => void;
   onSave: (secret: SecretSetting, clear?: boolean) => void;

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -20,6 +20,7 @@ import {
 import type { SettingsFormState } from "../components/settings";
 import {
   describeLlmCapability,
+  describeSecretSettingsFailure,
   formatIntegrationQueryState,
 } from "../components/settings/runtimeSemantics";
 import { Button } from "@/components/ui/button";
@@ -129,21 +130,35 @@ export default function SettingsPage() {
     retry: false,
   });
 
-  const { data: secretSettings } = useQuery({
+  const {
+    data: secretSettings,
+    isError: isSecretSettingsError,
+    error: secretSettingsError,
+  } = useQuery({
     queryKey: secretSettingsQueryKey,
     queryFn: () => api.getSecretSettings(effectiveAdminKey),
     enabled: hasAuthAttempt,
     retry: false,
   });
 
-  const { data: llmProviderHealth, isLoading: isLlmHealthLoading } = useQuery({
+  const {
+    data: llmProviderHealth,
+    isLoading: isLlmHealthLoading,
+    isError: isLlmHealthError,
+    error: llmHealthError,
+  } = useQuery({
     queryKey: llmProviderHealthQueryKey,
     queryFn: () => api.getLLMProviderHealth(effectiveAdminKey),
     enabled: hasAuthAttempt,
     retry: false,
   });
 
-  const { data: mcpProviderHealth, isLoading: isMcpHealthLoading } = useQuery({
+  const {
+    data: mcpProviderHealth,
+    isLoading: isMcpHealthLoading,
+    isError: isMcpHealthError,
+    error: mcpHealthError,
+  } = useQuery({
     queryKey: mcpProviderHealthQueryKey,
     queryFn: () => api.getMCPProviderHealth(effectiveAdminKey),
     enabled: hasAuthAttempt,
@@ -185,6 +200,11 @@ export default function SettingsPage() {
     JSON.stringify(form) !== JSON.stringify(lastSavedForm);
   const settingsErrorMessage =
     error instanceof Error ? error.message : "Unknown error";
+  const secretSettingsFailure = isSecretSettingsError
+    ? describeSecretSettingsFailure(
+        secretSettingsError instanceof Error ? secretSettingsError : null,
+      )
+    : null;
   const sessionAuthActive = AUTH_ENABLED && useSessionAuth;
   const sessionBootstrapPending =
     AUTH_ENABLED && !isApiAuthReady && adminKey.length === 0;
@@ -524,6 +544,7 @@ export default function SettingsPage() {
             <SetupChecklistCard status={data.setup_status} />
             <SecretSettingsCard
               secrets={secretSettings ?? []}
+              errorState={secretSettingsFailure}
               values={secretDrafts}
               onChange={(key, value) =>
                 setSecretDrafts((current) => ({ ...current, [key]: value }))
@@ -762,8 +783,12 @@ export default function SettingsPage() {
             setForm={setForm}
             llmProviderHealth={llmProviderHealth}
             isLlmHealthLoading={isLlmHealthLoading}
+            isLlmHealthError={isLlmHealthError}
+            llmHealthError={llmHealthError}
             mcpProviderHealth={mcpProviderHealth}
             isMcpHealthLoading={isMcpHealthLoading}
+            isMcpHealthError={isMcpHealthError}
+            mcpHealthError={mcpHealthError}
             llmCapabilitySummary={llmCapabilitySummary}
             hasUnsavedChanges={hasUnsavedChanges}
             newRepoInput={newRepoInput}
@@ -1080,12 +1105,18 @@ function SetupChecklistCard({ status }: { status: { ready: boolean; storage_boot
 
 function SecretSettingsCard({
   secrets,
+  errorState,
   values,
   onChange,
   onSave,
   pendingKey,
 }: {
   secrets: SecretSetting[];
+  errorState?: {
+    title: string;
+    detail: string;
+    guidance: string;
+  } | null;
   values: Record<string, string>;
   onChange: (key: string, value: string) => void;
   onSave: (secret: SecretSetting, clear?: boolean) => void;
@@ -1100,6 +1131,19 @@ function SecretSettingsCard({
         <p className="text-sm leading-6 text-[var(--ph-muted)]">
           Secrets are write-only. This page only shows configuration status, source, and safe hints.
         </p>
+        {errorState ? (
+          <div className="rounded-md border border-rose-500/30 bg-rose-500/5 px-3 py-3">
+            <p className="text-sm font-medium text-rose-500">
+              {errorState.title}
+            </p>
+            <p className="mt-1 text-sm text-[var(--ph-muted)]">
+              {errorState.detail}
+            </p>
+            <p className="mt-2 text-xs text-[var(--ph-muted)]">
+              {errorState.guidance}
+            </p>
+          </div>
+        ) : null}
         <div className="space-y-4">
           {secrets.map((secret) => (
             <div

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -29,6 +29,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
+import { SettingToggleField } from "../components/settings/SettingToggleField";
 
 export default function SettingsPage() {
   const queryClient = useQueryClient();
@@ -879,7 +880,7 @@ function SettingsSummarySection({
   );
 }
 
-function RuntimeWiringCard({
+export function RuntimeWiringCard({
   data,
   form,
   setForm,
@@ -967,28 +968,24 @@ function RuntimeWiringCard({
 
         <div className="space-y-4">
           <div className="rounded-md border border-[var(--ph-border)]/70 px-3 py-3">
-            <div className="flex items-center justify-between gap-3">
-              <div>
-                <div className="text-sm font-medium text-[var(--ph-text)]">Verify webhook signatures</div>
-                <p className="mt-1 text-xs leading-5 text-[var(--ph-muted)]">
-                  Keep this enabled in production unless you have a trusted intermediary in front of the webhook endpoint.
-                </p>
-              </div>
-              <Badge variant="outline">
-                {data.settings_metadata?.verify_webhook_signature?.source === "env" ? "Env override" : "Runtime"}
-              </Badge>
-            </div>
-            <div className="mt-3">
-              <Button
-                type="button"
-                variant={form.verify_webhook_signature ? "secondary" : "ghost"}
-                onClick={() =>
-                  setForm((current) => ({ ...current, verify_webhook_signature: !current.verify_webhook_signature }))
-                }
-              >
-                {form.verify_webhook_signature ? "Required" : "Disabled"}
-              </Button>
-            </div>
+            <SettingToggleField
+              label="Verify webhook signatures"
+              description="Keep this enabled in production unless you have a trusted intermediary in front of the webhook endpoint."
+              checked={form.verify_webhook_signature}
+              checkedLabel="Required"
+              uncheckedLabel="Disabled"
+              badgeLabel={
+                data.settings_metadata?.verify_webhook_signature?.source === "env"
+                  ? "Env override"
+                  : "Runtime"
+              }
+              onChange={(value) =>
+                setForm((current) => ({
+                  ...current,
+                  verify_webhook_signature: value,
+                }))
+              }
+            />
           </div>
 
           <div className="rounded-md border border-[var(--ph-border)]/70 px-3 py-3">
@@ -1004,18 +1001,24 @@ function RuntimeWiringCard({
               </Badge>
             </div>
             <div className="mt-3 grid gap-3 sm:grid-cols-2">
-              <div className="space-y-2">
-                <Label>Enabled</Label>
-                <Button
-                  type="button"
-                  variant={form.jenkins_bridge_enabled ? "secondary" : "ghost"}
-                  onClick={() =>
-                    setForm((current) => ({ ...current, jenkins_bridge_enabled: !current.jenkins_bridge_enabled }))
-                  }
-                >
-                  {form.jenkins_bridge_enabled ? "On" : "Off"}
-                </Button>
-              </div>
+              <SettingToggleField
+                label="Enabled"
+                description="Turn the Jenkins bridge runtime policy on or off. The shared secret stays in the separate secrets section."
+                checked={form.jenkins_bridge_enabled}
+                checkedLabel="On"
+                uncheckedLabel="Off"
+                badgeLabel={
+                  data.settings_metadata?.jenkins_bridge_enabled?.source === "env"
+                    ? "Env override"
+                    : "Runtime"
+                }
+                onChange={(value) =>
+                  setForm((current) => ({
+                    ...current,
+                    jenkins_bridge_enabled: value,
+                  }))
+                }
+              />
               <div className="space-y-2">
                 <Label>Max skew seconds</Label>
                 <Input

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -9,6 +9,10 @@ import { detectCachedAdminSession } from "../auth/adminSession";
 import { useApiAuthReady } from "../auth/apiAuthReady";
 import { AUTH_ENABLED } from "../auth/config";
 import {
+  getNextAdminKeyScopeId,
+  getSettingsQueryAuthScope,
+} from "../auth/settingsQueryAuthScope";
+import {
   AdminControlsForm,
   RuntimePolicyBanner,
   toSettingsForm,
@@ -30,6 +34,7 @@ export default function SettingsPage() {
   const isApiAuthReady = useApiAuthReady();
   const [adminKeyInput, setAdminKeyInput] = useState("");
   const [adminKey, setAdminKey] = useState("");
+  const [adminKeyScopeId, setAdminKeyScopeId] = useState<number | null>(null);
   const [useSessionAuth, setUseSessionAuth] = useState(false);
   const [newMcpRepoInput, setNewMcpRepoInput] = useState("");
   const [newHandoffHostInput, setNewHandoffHostInput] = useState("");
@@ -97,30 +102,49 @@ export default function SettingsPage() {
   const hasAuthAttempt =
     adminKey.length > 0 || (isApiAuthReady && useSessionAuth);
   const effectiveAdminKey = useSessionAuth ? undefined : adminKey;
+  const authQueryScope = getSettingsQueryAuthScope({
+    useSessionAuth,
+    adminKey,
+    adminKeyScopeId,
+  });
+  const settingsQueryKey = ["app-settings", authQueryScope] as const;
+  const secretSettingsQueryKey = ["secret-settings", authQueryScope] as const;
+  const llmProviderHealthQueryKey = [
+    "llm-provider-health",
+    authQueryScope,
+  ] as const;
+  const mcpProviderHealthQueryKey = [
+    "mcp-provider-health",
+    authQueryScope,
+  ] as const;
+  const handoffIntegrationStatusQueryKey = [
+    "agent-handoff-integration-status",
+    authQueryScope,
+  ] as const;
 
   const { data, isLoading, isError, error } = useQuery({
-    queryKey: ["app-settings", adminKey, useSessionAuth],
+    queryKey: settingsQueryKey,
     queryFn: () => api.getSettings(effectiveAdminKey),
     enabled: hasAuthAttempt,
     retry: false,
   });
 
   const { data: secretSettings } = useQuery({
-    queryKey: ["secret-settings", adminKey, useSessionAuth],
+    queryKey: secretSettingsQueryKey,
     queryFn: () => api.getSecretSettings(effectiveAdminKey),
     enabled: hasAuthAttempt,
     retry: false,
   });
 
   const { data: llmProviderHealth, isLoading: isLlmHealthLoading } = useQuery({
-    queryKey: ["llm-provider-health", adminKey, useSessionAuth],
+    queryKey: llmProviderHealthQueryKey,
     queryFn: () => api.getLLMProviderHealth(effectiveAdminKey),
     enabled: hasAuthAttempt,
     retry: false,
   });
 
   const { data: mcpProviderHealth, isLoading: isMcpHealthLoading } = useQuery({
-    queryKey: ["mcp-provider-health", adminKey, useSessionAuth],
+    queryKey: mcpProviderHealthQueryKey,
     queryFn: () => api.getMCPProviderHealth(effectiveAdminKey),
     enabled: hasAuthAttempt,
     retry: false,
@@ -131,7 +155,7 @@ export default function SettingsPage() {
     isError: isHandoffIntegrationError,
     error: handoffIntegrationError,
   } = useQuery({
-    queryKey: ["agent-handoff-integration-status", hasAuthAttempt],
+    queryKey: handoffIntegrationStatusQueryKey,
     queryFn: () => api.getAgentHandoffIntegrationStatus(),
     enabled: hasAuthAttempt,
     retry: false,
@@ -247,12 +271,9 @@ export default function SettingsPage() {
       setForm(next);
       setLastSavedForm(next);
       setGhAwWorkflowsInput(next.gh_aw_known_workflows.join(","));
-      queryClient.setQueryData(
-        ["app-settings", adminKey, useSessionAuth],
-        updated,
-      );
+      queryClient.setQueryData(settingsQueryKey, updated);
       await queryClient.invalidateQueries({
-        queryKey: ["app-settings", adminKey, useSessionAuth],
+        queryKey: settingsQueryKey,
       });
       toast.success("Settings saved", {
         description: "Changes are active now and persisted for future restarts unless overridden by env.",
@@ -281,10 +302,12 @@ export default function SettingsPage() {
         return next;
       });
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ["secret-settings", adminKey, useSessionAuth] }),
-        queryClient.invalidateQueries({ queryKey: ["app-settings", adminKey, useSessionAuth] }),
-        queryClient.invalidateQueries({ queryKey: ["llm-provider-health", adminKey, useSessionAuth] }),
-        queryClient.invalidateQueries({ queryKey: ["agent-handoff-integration-status", hasAuthAttempt] }),
+        queryClient.invalidateQueries({ queryKey: secretSettingsQueryKey }),
+        queryClient.invalidateQueries({ queryKey: settingsQueryKey }),
+        queryClient.invalidateQueries({ queryKey: llmProviderHealthQueryKey }),
+        queryClient.invalidateQueries({
+          queryKey: handoffIntegrationStatusQueryKey,
+        }),
       ]);
       toast.success("Secret updated", {
         description: "The value was stored without being returned to the UI.",
@@ -346,6 +369,7 @@ export default function SettingsPage() {
     }
     setUseSessionAuth(false);
     setAdminKey(trimmed);
+    setAdminKeyScopeId((current) => getNextAdminKeyScopeId(current));
     setAdminKeyInput("");
   };
 


### PR DESCRIPTION
## Goal
Draft review gate PR for batching small finished issue fixes before any merge to `main`.

## Included now
- #168, fixes #158: remove `X-Admin-Key` from Settings React Query cache keys
- #170, fixes #157: distinguish failed Settings subqueries from real empty or unavailable states
- #171, fixes #156: improve Settings page accessibility for section navigation and boolean controls

## Workflow
- keep issue-sized work on separate branches/PRs
- cherry-pick finished issue commits into this integration branch
- review the combined batch here
- merge this parent PR only when the batch is ready

## Validation
- `cd frontend && npx vitest run src/components/settings/runtimeSemantics.test.ts src/components/settings/settingsAccessibility.test.tsx`
- `cd frontend && npx eslint src/pages/Settings.tsx src/components/settings/AdminControlsForm.tsx src/components/settings/runtimeSemantics.ts src/components/settings/runtimeSemantics.test.ts src/components/settings/SettingToggleField.tsx src/components/settings/settingsAccessibility.test.tsx`
- `cd frontend && npm run build`

## Notes
- this PR is the batch/review gate, not the place to do unrelated work

## Issue Closure
Closes #156
Closes #157
Closes #158
