### PR TITLE
fix: distinguish failed Settings subqueries

### DIFF
--- a/frontend/src/components/settings/AdminControlsForm.tsx
+++ b/frontend/src/components/settings/AdminControlsForm.tsx
@@ -28,6 +28,8 @@ import {
 } from "./types";
 import {
   describeLlmCapability,
+  describeLlmHealthFailure,
+  describeMcpHealthFailure,
   formatLlmValidationLabel,
   formatSettingSource,
   getDurabilityLabel,
@@ -70,8 +72,12 @@ interface Props {
   setForm: Dispatch<SetStateAction<SettingsFormState>>;
   llmProviderHealth?: LLMProviderHealth;
   isLlmHealthLoading?: boolean;
+  isLlmHealthError?: boolean;
+  llmHealthError?: Error | null;
   mcpProviderHealth?: MCPProviderHealth;
   isMcpHealthLoading?: boolean;
+  isMcpHealthError?: boolean;
+  mcpHealthError?: Error | null;
   llmCapabilitySummary?: {
     summary: string;
     detail: string;
@@ -368,8 +374,12 @@ export default function AdminControlsForm({
   setForm,
   llmProviderHealth,
   isLlmHealthLoading,
+  isLlmHealthError,
+  llmHealthError,
   mcpProviderHealth,
   isMcpHealthLoading,
+  isMcpHealthError,
+  mcpHealthError,
   llmCapabilitySummary,
   hasUnsavedChanges,
   newRepoInput,
@@ -435,6 +445,12 @@ export default function AdminControlsForm({
   const resolvedLlmCapability =
     llmCapabilitySummary ?? describeLlmCapability(llmProviderHealth);
   const llmValidationLabel = formatLlmValidationLabel(llmProviderHealth);
+  const llmHealthFailure = isLlmHealthError
+    ? describeLlmHealthFailure(llmHealthError)
+    : null;
+  const mcpHealthFailure = isMcpHealthError
+    ? describeMcpHealthFailure(mcpHealthError)
+    : null;
   const taskModelPreview = [
     {
       key: "analysis",
@@ -1339,15 +1355,21 @@ export default function AdminControlsForm({
                   value={
                     isLlmHealthLoading
                       ? "Checking..."
+                      : isLlmHealthError
+                        ? "Request failed"
                       : llmProviderHealth
                         ? `${llmProviderHealth.available ? "Available" : "Unavailable"} (${llmProviderHealth.reason})`
                         : "Unavailable"
                   }
+                  description={llmHealthFailure?.detail}
+                  guidance={llmHealthFailure?.guidance}
                 />
                 <ReadOnlyField
                   label="Provider Status"
                   value={
-                    llmProviderHealth
+                    isLlmHealthError
+                      ? "Unknown"
+                      : llmProviderHealth
                       ? llmProviderHealth.implemented
                         ? "Implemented"
                         : "Scaffolded only"
@@ -1359,20 +1381,32 @@ export default function AdminControlsForm({
                   value={
                     isLlmHealthLoading
                       ? "Checking..."
+                      : isLlmHealthError
+                        ? "Request failed"
                       : resolvedLlmCapability.summary
                   }
+                  description={llmHealthFailure?.detail}
+                  guidance={llmHealthFailure?.guidance}
                 />
                 <ReadOnlyField
                   label="Last validation"
                   value={
-                    isLlmHealthLoading ? "Checking..." : llmValidationLabel
+                    isLlmHealthLoading
+                      ? "Checking..."
+                      : isLlmHealthError
+                        ? "Unavailable"
+                        : llmValidationLabel
                   }
+                  description={llmHealthFailure?.detail}
+                  guidance={llmHealthFailure?.guidance}
                 />
               </div>
               <p className="text-xs text-[var(--ph-muted)]">
                 {isLlmHealthLoading
                   ? "Checking recent live LLM capability evidence..."
-                  : resolvedLlmCapability.detail}
+                  : isLlmHealthError
+                    ? `${llmHealthFailure?.detail} ${llmHealthFailure?.guidance}`
+                    : resolvedLlmCapability.detail}
               </p>
               <Separator />
               <div className="space-y-3">
@@ -1958,10 +1992,14 @@ export default function AdminControlsForm({
                   value={
                     isMcpHealthLoading
                       ? "Checking..."
+                      : isMcpHealthError
+                        ? "Probe failed"
                       : mcpProviderHealth
                         ? `${mcpProviderHealth.available ? "Available" : "Unavailable"} (${mcpProviderHealth.reason})`
                         : "Unavailable"
                   }
+                  description={mcpHealthFailure?.detail}
+                  guidance={mcpHealthFailure?.guidance}
                 />
               </div>
               <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
@@ -2922,10 +2960,14 @@ function SwitchField({
 function ReadOnlyField({
   label,
   value,
+  description,
+  guidance,
   metadata,
 }: {
   label: string;
   value: string | number;
+  description?: string;
+  guidance?: string;
   metadata?: AppSettingMetadata;
 }) {
   const durability = getDurabilityLabel(metadata);
@@ -2950,6 +2992,12 @@ function ReadOnlyField({
           <span className="text-[var(--ph-muted)] italic">Not set</span>
         )}
       </p>
+      {description ? (
+        <p className="text-xs text-[var(--ph-muted)]">{description}</p>
+      ) : null}
+      {guidance ? (
+        <p className="text-xs text-[var(--ph-muted)]">{guidance}</p>
+      ) : null}
       {metadata?.note ? (
         <p className="text-xs text-[var(--ph-muted)]">{metadata.note}</p>
       ) : null}

--- a/frontend/src/components/settings/runtimeSemantics.test.ts
+++ b/frontend/src/components/settings/runtimeSemantics.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  describeLlmHealthFailure,
+  describeMcpHealthFailure,
+  describeSecretSettingsFailure,
+  formatIntegrationQueryState,
+} from "./runtimeSemantics";
+
+describe("runtimeSemantics subquery failures", () => {
+  it("surfaces explicit secret settings failures with retry guidance", () => {
+    expect(describeSecretSettingsFailure(new Error("401 Unauthorized"))).toEqual({
+      title: "Secret settings request failed",
+      detail: "401 Unauthorized",
+      guidance:
+        "Check the active auth method and secret backend configuration, then retry.",
+    });
+  });
+
+  it("falls back to a stable LLM failure message when the error is absent", () => {
+    expect(describeLlmHealthFailure()).toEqual({
+      title: "LLM health request failed",
+      detail: "LLM health request failed.",
+      guidance:
+        "Check the active auth method and LLM provider health configuration, then retry.",
+    });
+  });
+
+  it("preserves MCP probe failure detail instead of collapsing to unavailable", () => {
+    expect(describeMcpHealthFailure(new Error("gateway timeout"))).toEqual({
+      title: "MCP health request failed",
+      detail: "gateway timeout",
+      guidance:
+        "Check the active auth method and MCP provider health configuration, then retry.",
+    });
+  });
+
+  it("keeps integration probe failures distinct from normal unavailable states", () => {
+    expect(
+      formatIntegrationQueryState({
+        isError: true,
+        error: new Error("invalid bearer token"),
+      }),
+    ).toEqual({
+      summary: "Probe failed",
+      detail: "invalid bearer token",
+      tone: "bad",
+    });
+  });
+});

--- a/frontend/src/components/settings/runtimeSemantics.ts
+++ b/frontend/src/components/settings/runtimeSemantics.ts
@@ -16,6 +16,62 @@ export type McpEffectiveState = {
 
 export type IntegrationTone = 'ok' | 'warn' | 'bad' | 'muted'
 
+export type SubqueryFailureState = {
+  title: string
+  detail: string
+  guidance: string
+}
+
+function formatSubqueryFailure(args: {
+  title: string
+  fallbackDetail: string
+  guidance: string
+  error?: Error | null
+}): SubqueryFailureState {
+  const detail = args.error?.message?.trim() || args.fallbackDetail
+  return {
+    title: args.title,
+    detail,
+    guidance: args.guidance,
+  }
+}
+
+export function describeSecretSettingsFailure(
+  error?: Error | null
+): SubqueryFailureState {
+  return formatSubqueryFailure({
+    title: 'Secret settings request failed',
+    fallbackDetail: 'Secrets request failed.',
+    guidance:
+      'Check the active auth method and secret backend configuration, then retry.',
+    error,
+  })
+}
+
+export function describeLlmHealthFailure(
+  error?: Error | null
+): SubqueryFailureState {
+  return formatSubqueryFailure({
+    title: 'LLM health request failed',
+    fallbackDetail: 'LLM health request failed.',
+    guidance:
+      'Check the active auth method and LLM provider health configuration, then retry.',
+    error,
+  })
+}
+
+export function describeMcpHealthFailure(
+  error?: Error | null
+): SubqueryFailureState {
+  return formatSubqueryFailure({
+    title: 'MCP health request failed',
+    fallbackDetail: 'MCP health request failed.',
+    guidance:
+      'Check the active auth method and MCP provider health configuration, then retry.',
+    error,
+  })
+}
+
 export function describeLlmCapability(
   health?: LLMProviderHealth
 ): { summary: string; detail: string; tone: IntegrationTone } {

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -18,6 +18,7 @@ import {
   describeLlmCapability,
   describeSecretSettingsFailure,
   formatIntegrationQueryState,
+  type SubqueryFailureState,
 } from "../components/settings/runtimeSemantics";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -1088,11 +1089,7 @@ function SecretSettingsCard({
   pendingKey,
 }: {
   secrets: SecretSetting[];
-  errorState?: {
-    title: string;
-    detail: string;
-    guidance: string;
-  } | null;
+  errorState?: SubqueryFailureState | null;
   values: Record<string, string>;
   onChange: (key: string, value: string) => void;
   onSave: (secret: SecretSetting, clear?: boolean) => void;

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -16,6 +16,7 @@ import {
 import type { SettingsFormState } from "../components/settings";
 import {
   describeLlmCapability,
+  describeSecretSettingsFailure,
   formatIntegrationQueryState,
 } from "../components/settings/runtimeSemantics";
 import { Button } from "@/components/ui/button";
@@ -105,21 +106,35 @@ export default function SettingsPage() {
     retry: false,
   });
 
-  const { data: secretSettings } = useQuery({
+  const {
+    data: secretSettings,
+    isError: isSecretSettingsError,
+    error: secretSettingsError,
+  } = useQuery({
     queryKey: ["secret-settings", adminKey, useSessionAuth],
     queryFn: () => api.getSecretSettings(effectiveAdminKey),
     enabled: hasAuthAttempt,
     retry: false,
   });
 
-  const { data: llmProviderHealth, isLoading: isLlmHealthLoading } = useQuery({
+  const {
+    data: llmProviderHealth,
+    isLoading: isLlmHealthLoading,
+    isError: isLlmHealthError,
+    error: llmHealthError,
+  } = useQuery({
     queryKey: ["llm-provider-health", adminKey, useSessionAuth],
     queryFn: () => api.getLLMProviderHealth(effectiveAdminKey),
     enabled: hasAuthAttempt,
     retry: false,
   });
 
-  const { data: mcpProviderHealth, isLoading: isMcpHealthLoading } = useQuery({
+  const {
+    data: mcpProviderHealth,
+    isLoading: isMcpHealthLoading,
+    isError: isMcpHealthError,
+    error: mcpHealthError,
+  } = useQuery({
     queryKey: ["mcp-provider-health", adminKey, useSessionAuth],
     queryFn: () => api.getMCPProviderHealth(effectiveAdminKey),
     enabled: hasAuthAttempt,
@@ -161,6 +176,11 @@ export default function SettingsPage() {
     JSON.stringify(form) !== JSON.stringify(lastSavedForm);
   const settingsErrorMessage =
     error instanceof Error ? error.message : "Unknown error";
+  const secretSettingsFailure = isSecretSettingsError
+    ? describeSecretSettingsFailure(
+        secretSettingsError instanceof Error ? secretSettingsError : null,
+      )
+    : null;
   const sessionAuthActive = AUTH_ENABLED && useSessionAuth;
   const sessionBootstrapPending =
     AUTH_ENABLED && !isApiAuthReady && adminKey.length === 0;
@@ -500,6 +520,7 @@ export default function SettingsPage() {
             <SetupChecklistCard status={data.setup_status} />
             <SecretSettingsCard
               secrets={secretSettings ?? []}
+              errorState={secretSettingsFailure}
               values={secretDrafts}
               onChange={(key, value) =>
                 setSecretDrafts((current) => ({ ...current, [key]: value }))
@@ -738,8 +759,12 @@ export default function SettingsPage() {
             setForm={setForm}
             llmProviderHealth={llmProviderHealth}
             isLlmHealthLoading={isLlmHealthLoading}
+            isLlmHealthError={isLlmHealthError}
+            llmHealthError={llmHealthError}
             mcpProviderHealth={mcpProviderHealth}
             isMcpHealthLoading={isMcpHealthLoading}
+            isMcpHealthError={isMcpHealthError}
+            mcpHealthError={mcpHealthError}
             llmCapabilitySummary={llmCapabilitySummary}
             hasUnsavedChanges={hasUnsavedChanges}
             newRepoInput={newRepoInput}
@@ -1056,12 +1081,18 @@ function SetupChecklistCard({ status }: { status: { ready: boolean; storage_boot
 
 function SecretSettingsCard({
   secrets,
+  errorState,
   values,
   onChange,
   onSave,
   pendingKey,
 }: {
   secrets: SecretSetting[];
+  errorState?: {
+    title: string;
+    detail: string;
+    guidance: string;
+  } | null;
   values: Record<string, string>;
   onChange: (key: string, value: string) => void;
   onSave: (secret: SecretSetting, clear?: boolean) => void;
@@ -1076,6 +1107,19 @@ function SecretSettingsCard({
         <p className="text-sm leading-6 text-[var(--ph-muted)]">
           Secrets are write-only. This page only shows configuration status, source, and safe hints.
         </p>
+        {errorState ? (
+          <div className="rounded-md border border-rose-500/30 bg-rose-500/5 px-3 py-3">
+            <p className="text-sm font-medium text-rose-500">
+              {errorState.title}
+            </p>
+            <p className="mt-1 text-sm text-[var(--ph-muted)]">
+              {errorState.detail}
+            </p>
+            <p className="mt-2 text-xs text-[var(--ph-muted)]">
+              {errorState.guidance}
+            </p>
+          </div>
+        ) : null}
         <div className="space-y-4">
           {secrets.map((secret) => (
             <div


### PR DESCRIPTION
## Summary
- surface explicit secret-settings fetch failures instead of rendering an empty secrets state
- show LLM and MCP health request/probe failures as failures with recovery guidance
- add runtime semantics regression coverage for the new subquery failure states

## Why
The Settings page was collapsing several failed subqueries into normal empty or unavailable states, which can mislead operators during auth or transport incidents.

## Validation
- `cd frontend && npx vitest run src/components/settings/runtimeSemantics.test.ts`
- `cd frontend && npx eslint src/pages/Settings.tsx src/components/settings/AdminControlsForm.tsx src/components/settings/runtimeSemantics.ts src/components/settings/runtimeSemantics.test.ts`
- `cd frontend && npm run build`

Closes #157