### PR TITLE
fix: improve Settings page accessibility

### DIFF
--- a/frontend/src/components/settings/AdminControlsForm.tsx
+++ b/frontend/src/components/settings/AdminControlsForm.tsx
@@ -1,4 +1,4 @@
-import { useState, type Dispatch, type SetStateAction } from "react";
+import { useId, useState, type Dispatch, type SetStateAction } from "react";
 import {
   ChevronDown,
   Copy,
@@ -56,7 +56,6 @@ import {
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Tooltip,
   TooltipContent,
@@ -93,6 +92,77 @@ interface Props {
 }
 
 type SettingsSection = "runtime" | "intelligence" | "security";
+
+const SETTINGS_SECTION_OPTIONS: Array<{
+  value: SettingsSection;
+  label: string;
+  summary: string;
+  Icon: typeof Zap;
+}> = [
+  {
+    value: "runtime",
+    label: "1. Runtime Controls",
+    summary:
+      "Runtime Controls: set remediation behavior, repo scope, and operation mode first.",
+    Icon: Zap,
+  },
+  {
+    value: "intelligence",
+    label: "2. AI & Integrations",
+    summary:
+      "AI & Integrations: configure model providers, handoff, external diagnostics, and MCP policies.",
+    Icon: Sparkles,
+  },
+  {
+    value: "security",
+    label: "3. Security & Advanced",
+    summary:
+      "Security & Advanced: adjust auth posture, retries, limits, and low-level safeguards.",
+    Icon: Shield,
+  },
+];
+
+export function SettingsSectionSwitcher({
+  activeSection,
+  onChange,
+}: {
+  activeSection: SettingsSection;
+  onChange: (section: SettingsSection) => void;
+}) {
+  const activeOption =
+    SETTINGS_SECTION_OPTIONS.find((option) => option.value === activeSection) ??
+    SETTINGS_SECTION_OPTIONS[0];
+
+  return (
+    <>
+      <nav aria-label="Settings sections">
+        <ul className="grid h-auto list-none grid-cols-1 gap-4 p-0 sm:grid-cols-3">
+          {SETTINGS_SECTION_OPTIONS.map(({ value, label, Icon }) => {
+            const isActive = value === activeSection;
+            return (
+              <li key={value}>
+                <Button
+                  type="button"
+                  variant={isActive ? "secondary" : "ghost"}
+                  className="w-full justify-center gap-2 py-3 text-sm font-semibold"
+                  aria-pressed={isActive}
+                  id={`settings-section-trigger-${value}`}
+                  onClick={() => onChange(value)}
+                >
+                  <Icon className="h-4 w-4" />
+                  {label}
+                </Button>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+      <p className="mt-3 text-sm text-[var(--ph-muted)]">
+        {activeOption.summary}
+      </p>
+    </>
+  );
+}
 type NotificationTargetType =
   | "email"
   | "webhook"
@@ -633,45 +703,10 @@ export default function AdminControlsForm({
       <div className="space-y-8">
         <Card>
           <CardContent className="py-5">
-            <Tabs
-              value={activeSection}
-              onValueChange={(value) =>
-                setActiveSection(value as SettingsSection)
-              }
-              className="w-full"
-            >
-              <TabsList className="grid h-auto w-full grid-cols-1 gap-4 sm:grid-cols-3">
-                <TabsTrigger
-                  value="runtime"
-                  className="flex items-center justify-center gap-2 py-3 text-sm font-semibold"
-                >
-                  <Zap className="h-4 w-4" />
-                  1. Runtime Controls
-                </TabsTrigger>
-                <TabsTrigger
-                  value="intelligence"
-                  className="flex items-center justify-center gap-2 py-3 text-sm font-semibold"
-                >
-                  <Sparkles className="h-4 w-4" />
-                  2. AI & Integrations
-                </TabsTrigger>
-                <TabsTrigger
-                  value="security"
-                  className="flex items-center justify-center gap-2 py-3 text-sm font-semibold"
-                >
-                  <Shield className="h-4 w-4" />
-                  3. Security & Advanced
-                </TabsTrigger>
-              </TabsList>
-            </Tabs>
-            <p className="mt-3 text-sm text-[var(--ph-muted)]">
-              {activeSection === "runtime" &&
-                "Runtime Controls: set remediation behavior, repo scope, and operation mode first."}
-              {activeSection === "intelligence" &&
-                "AI & Integrations: configure model providers, handoff, external diagnostics, and MCP policies."}
-              {activeSection === "security" &&
-                "Security & Advanced: adjust auth posture, retries, limits, and low-level safeguards."}
-            </p>
+            <SettingsSectionSwitcher
+              activeSection={activeSection}
+              onChange={setActiveSection}
+            />
           </CardContent>
         </Card>
 
@@ -2874,7 +2909,7 @@ function FieldGroup({
   );
 }
 
-function SwitchField({
+export function SwitchField({
   label,
   field,
   checked,
@@ -2889,15 +2924,21 @@ function SwitchField({
 }) {
   const desc = SETTING_DESCRIPTIONS[field];
   const durability = getDurabilityLabel(metadata);
+  const switchId = useId();
+  const descriptionId = desc ? `${switchId}-description` : undefined;
+
   return (
     <div className="flex items-start gap-3 py-1">
-      <Switch checked={checked} onCheckedChange={onChange} className="mt-0.5" />
+      <Switch
+        id={switchId}
+        checked={checked}
+        onCheckedChange={onChange}
+        className="mt-0.5"
+        aria-describedby={descriptionId}
+      />
       <div>
         <div className="flex flex-wrap items-center gap-1.5">
-          <Label
-            className="text-[var(--ph-text)] cursor-pointer"
-            onClick={() => onChange(!checked)}
-          >
+          <Label htmlFor={switchId} className="text-[var(--ph-text)] cursor-pointer">
             {label}
           </Label>
           {metadata && (
@@ -2912,7 +2953,9 @@ function SwitchField({
           )}
         </div>
         {desc && (
-          <p className="text-xs text-[var(--ph-muted)] mt-0.5">{desc}</p>
+          <p id={descriptionId} className="text-xs text-[var(--ph-muted)] mt-0.5">
+            {desc}
+          </p>
         )}
       </div>
     </div>

--- a/frontend/src/components/settings/SettingToggleField.tsx
+++ b/frontend/src/components/settings/SettingToggleField.tsx
@@ -23,6 +23,8 @@ export function SettingToggleField({
 }) {
   const switchId = useId();
   const descriptionId = `${switchId}-description`;
+  const stateId = `${switchId}-state`;
+  const stateLabel = checked ? checkedLabel : uncheckedLabel;
 
   return (
     <div className="space-y-3">
@@ -48,14 +50,16 @@ export function SettingToggleField({
           id={switchId}
           checked={checked}
           onCheckedChange={onChange}
-          aria-describedby={descriptionId}
+          aria-describedby={`${descriptionId} ${stateId}`}
         />
-        <Label
-          htmlFor={switchId}
-          className="cursor-pointer text-sm text-[var(--ph-text)]"
+        <span
+          id={stateId}
+          aria-live="polite"
+          className="text-sm text-[var(--ph-text)]"
         >
-          {checked ? checkedLabel : uncheckedLabel}
-        </Label>
+          <span className="sr-only">Current state: </span>
+          {stateLabel}
+        </span>
       </div>
     </div>
   );

--- a/frontend/src/components/settings/SettingToggleField.tsx
+++ b/frontend/src/components/settings/SettingToggleField.tsx
@@ -1,0 +1,62 @@
+import { useId } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+
+export function SettingToggleField({
+  label,
+  description,
+  checked,
+  checkedLabel,
+  uncheckedLabel,
+  badgeLabel,
+  onChange,
+}: {
+  label: string;
+  description: string;
+  checked: boolean;
+  checkedLabel: string;
+  uncheckedLabel: string;
+  badgeLabel: string;
+  onChange: (value: boolean) => void;
+}) {
+  const switchId = useId();
+  const descriptionId = `${switchId}-description`;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <Label
+            htmlFor={switchId}
+            className="cursor-pointer text-sm font-medium text-[var(--ph-text)]"
+          >
+            {label}
+          </Label>
+          <p
+            id={descriptionId}
+            className="mt-1 text-xs leading-5 text-[var(--ph-muted)]"
+          >
+            {description}
+          </p>
+        </div>
+        <Badge variant="outline">{badgeLabel}</Badge>
+      </div>
+      <div className="flex items-center gap-3">
+        <Switch
+          id={switchId}
+          checked={checked}
+          onCheckedChange={onChange}
+          aria-describedby={descriptionId}
+        />
+        <Label
+          htmlFor={switchId}
+          className="cursor-pointer text-sm text-[var(--ph-text)]"
+        >
+          {checked ? checkedLabel : uncheckedLabel}
+        </Label>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/settingsAccessibility.test.tsx
+++ b/frontend/src/components/settings/settingsAccessibility.test.tsx
@@ -1,0 +1,61 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { SettingToggleField } from "./SettingToggleField";
+import { SettingsSectionSwitcher, SwitchField } from "./AdminControlsForm";
+
+describe("Settings accessibility smoke checks", () => {
+  it("renders the section switcher as a labelled pressed-button navigation control", () => {
+    const markup = renderToStaticMarkup(
+      <SettingsSectionSwitcher
+        activeSection="security"
+        onChange={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain('aria-label="Settings sections"');
+    expect(markup).toContain('id="settings-section-trigger-security"');
+    expect(markup).toContain('aria-pressed="true"');
+  });
+
+  it("associates admin switch labels and descriptions with the switch control", () => {
+    const markup = renderToStaticMarkup(
+      <SwitchField
+        label="Retry failed workflows"
+        field="auto_retry_workflow"
+        checked
+        onChange={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain('role="switch"');
+    expect(markup).toMatch(
+      /role="switch"[\s\S]*id=(?:"|')?([^"'> ]+)(?:"|')?[\s\S]*<label[^>]*for=(?:"|')?\1(?:"|')?[^>]*>Retry failed workflows<\/label>/,
+    );
+    expect(markup).toMatch(
+      /role="switch"[\s\S]*aria-describedby=(?:"|')?([^"'> ]+)(?:"|')?[\s\S]*<p id=(?:"|')?\1(?:"|')?[\s\S]*Allows PipelineHealer to trigger retry of failed workflow jobs/,
+    );
+  });
+
+  it("associates runtime wiring toggles with the switch control and visible state label", () => {
+    const markup = renderToStaticMarkup(
+      <SettingToggleField
+        label="Verify webhook signatures"
+        description="Keep this enabled in production."
+        checked
+        checkedLabel="Required"
+        uncheckedLabel="Disabled"
+        badgeLabel="Runtime"
+        onChange={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain('role="switch"');
+    expect(markup).toMatch(
+      /<label[^>]*for=(?:"|')?([^"'> ]+)(?:"|')?[^>]*>Verify webhook signatures<\/label>[\s\S]*role="switch"[\s\S]*id=(?:"|')?\1(?:"|')?/,
+    );
+    expect(markup).toMatch(
+      /<label[^>]*for=(?:"|')?([^"'> ]+)(?:"|')?[^>]*>Required<\/label>[\s\S]*$/,
+    );
+  });
+});

--- a/frontend/src/components/settings/settingsAccessibility.test.tsx
+++ b/frontend/src/components/settings/settingsAccessibility.test.tsx
@@ -4,6 +4,26 @@ import { describe, expect, it } from "vitest";
 import { SettingToggleField } from "./SettingToggleField";
 import { SettingsSectionSwitcher, SwitchField } from "./AdminControlsForm";
 
+function escapeRegex(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function getSwitchId(markup: string) {
+  const match = markup.match(
+    /role="switch"[\s\S]*?id=(?:"|')?([^"'> ]+)(?:"|')?/,
+  );
+  expect(match).not.toBeNull();
+  return match?.[1] ?? "";
+}
+
+function getSwitchDescribedByIds(markup: string) {
+  const match = markup.match(
+    /role="switch"[\s\S]*?aria-describedby=(?:"|')?([^"'>]+)(?:"|')?/,
+  );
+  expect(match).not.toBeNull();
+  return (match?.[1] ?? "").split(/\s+/).filter(Boolean);
+}
+
 describe("Settings accessibility smoke checks", () => {
   it("renders the section switcher as a labelled pressed-button navigation control", () => {
     const markup = renderToStaticMarkup(
@@ -28,16 +48,24 @@ describe("Settings accessibility smoke checks", () => {
       />,
     );
 
+    const switchId = getSwitchId(markup);
+    const describedByIds = getSwitchDescribedByIds(markup);
+
     expect(markup).toContain('role="switch"');
     expect(markup).toMatch(
-      /role="switch"[\s\S]*id=(?:"|')?([^"'> ]+)(?:"|')?[\s\S]*<label[^>]*for=(?:"|')?\1(?:"|')?[^>]*>Retry failed workflows<\/label>/,
+      new RegExp(
+        `<label[^>]*for=(?:"|')?${escapeRegex(switchId)}(?:"|')?[^>]*>Retry failed workflows<\\/label>`,
+      ),
     );
+    expect(describedByIds).toHaveLength(1);
     expect(markup).toMatch(
-      /role="switch"[\s\S]*aria-describedby=(?:"|')?([^"'> ]+)(?:"|')?[\s\S]*<p id=(?:"|')?\1(?:"|')?[\s\S]*Allows PipelineHealer to trigger retry of failed workflow jobs/,
+      new RegExp(
+        `<p id=(?:"|')?${escapeRegex(describedByIds[0])}(?:"|')?[^>]*>`,
+      ),
     );
   });
 
-  it("associates runtime wiring toggles with the switch control and visible state label", () => {
+  it("associates runtime wiring toggles with one label, descriptive help text, and state text", () => {
     const markup = renderToStaticMarkup(
       <SettingToggleField
         label="Verify webhook signatures"
@@ -50,12 +78,32 @@ describe("Settings accessibility smoke checks", () => {
       />,
     );
 
+    const switchId = getSwitchId(markup);
+    const describedByIds = getSwitchDescribedByIds(markup);
+    const labelsForSwitch = markup.match(
+      new RegExp(
+        `<label[^>]*for=(?:"|')?${escapeRegex(switchId)}(?:"|')?`,
+        "g",
+      ),
+    );
+
     expect(markup).toContain('role="switch"');
+    expect(labelsForSwitch).toHaveLength(1);
     expect(markup).toMatch(
-      /<label[^>]*for=(?:"|')?([^"'> ]+)(?:"|')?[^>]*>Verify webhook signatures<\/label>[\s\S]*role="switch"[\s\S]*id=(?:"|')?\1(?:"|')?/,
+      new RegExp(
+        `<label[^>]*for=(?:"|')?${escapeRegex(switchId)}(?:"|')?[^>]*>Verify webhook signatures<\\/label>`,
+      ),
+    );
+    expect(describedByIds).toHaveLength(2);
+    expect(markup).toMatch(
+      new RegExp(
+        `<p id=(?:"|')?${escapeRegex(describedByIds[0])}(?:"|')?[^>]*>`,
+      ),
     );
     expect(markup).toMatch(
-      /<label[^>]*for=(?:"|')?([^"'> ]+)(?:"|')?[^>]*>Required<\/label>[\s\S]*$/,
+      new RegExp(
+        `<span id=(?:"|')?${escapeRegex(describedByIds[1])}(?:"|')?[^>]*aria-live="polite"`,
+      ),
     );
   });
 });

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -24,6 +24,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
+import { SettingToggleField } from "../components/settings/SettingToggleField";
 
 export default function SettingsPage() {
   const queryClient = useQueryClient();
@@ -830,7 +831,7 @@ function SettingsSummarySection({
   );
 }
 
-function RuntimeWiringCard({
+export function RuntimeWiringCard({
   data,
   form,
   setForm,
@@ -918,28 +919,24 @@ function RuntimeWiringCard({
 
         <div className="space-y-4">
           <div className="rounded-md border border-[var(--ph-border)]/70 px-3 py-3">
-            <div className="flex items-center justify-between gap-3">
-              <div>
-                <div className="text-sm font-medium text-[var(--ph-text)]">Verify webhook signatures</div>
-                <p className="mt-1 text-xs leading-5 text-[var(--ph-muted)]">
-                  Keep this enabled in production unless you have a trusted intermediary in front of the webhook endpoint.
-                </p>
-              </div>
-              <Badge variant="outline">
-                {data.settings_metadata?.verify_webhook_signature?.source === "env" ? "Env override" : "Runtime"}
-              </Badge>
-            </div>
-            <div className="mt-3">
-              <Button
-                type="button"
-                variant={form.verify_webhook_signature ? "secondary" : "ghost"}
-                onClick={() =>
-                  setForm((current) => ({ ...current, verify_webhook_signature: !current.verify_webhook_signature }))
-                }
-              >
-                {form.verify_webhook_signature ? "Required" : "Disabled"}
-              </Button>
-            </div>
+            <SettingToggleField
+              label="Verify webhook signatures"
+              description="Keep this enabled in production unless you have a trusted intermediary in front of the webhook endpoint."
+              checked={form.verify_webhook_signature}
+              checkedLabel="Required"
+              uncheckedLabel="Disabled"
+              badgeLabel={
+                data.settings_metadata?.verify_webhook_signature?.source === "env"
+                  ? "Env override"
+                  : "Runtime"
+              }
+              onChange={(value) =>
+                setForm((current) => ({
+                  ...current,
+                  verify_webhook_signature: value,
+                }))
+              }
+            />
           </div>
 
           <div className="rounded-md border border-[var(--ph-border)]/70 px-3 py-3">
@@ -955,18 +952,24 @@ function RuntimeWiringCard({
               </Badge>
             </div>
             <div className="mt-3 grid gap-3 sm:grid-cols-2">
-              <div className="space-y-2">
-                <Label>Enabled</Label>
-                <Button
-                  type="button"
-                  variant={form.jenkins_bridge_enabled ? "secondary" : "ghost"}
-                  onClick={() =>
-                    setForm((current) => ({ ...current, jenkins_bridge_enabled: !current.jenkins_bridge_enabled }))
-                  }
-                >
-                  {form.jenkins_bridge_enabled ? "On" : "Off"}
-                </Button>
-              </div>
+              <SettingToggleField
+                label="Enabled"
+                description="Turn the Jenkins bridge runtime policy on or off. The shared secret stays in the separate secrets section."
+                checked={form.jenkins_bridge_enabled}
+                checkedLabel="On"
+                uncheckedLabel="Off"
+                badgeLabel={
+                  data.settings_metadata?.jenkins_bridge_enabled?.source === "env"
+                    ? "Env override"
+                    : "Runtime"
+                }
+                onChange={(value) =>
+                  setForm((current) => ({
+                    ...current,
+                    jenkins_bridge_enabled: value,
+                  }))
+                }
+              />
               <div className="space-y-2">
                 <Label>Max skew seconds</Label>
                 <Input


### PR DESCRIPTION
## Summary
- replace the pseudo-tab section switcher with labelled pressed-button navigation
- bind settings switches to explicit labels and descriptions with `htmlFor` and `aria-describedby`
- replace runtime wiring toggle buttons with accessible switch controls and add an accessibility smoke test

## Why
The Settings page section switcher was using tab triggers without matching tab panels, and several boolean controls did not expose state and labeling strongly enough for keyboard and assistive-technology users.

## Validation
- `cd frontend && npx vitest run src/components/settings/settingsAccessibility.test.tsx`
- `cd frontend && npx eslint src/components/settings/AdminControlsForm.tsx src/components/settings/SettingToggleField.tsx src/pages/Settings.tsx src/components/settings/settingsAccessibility.test.tsx`
- `cd frontend && npm run build`

Closes #156