### PR TITLE
docs: add production v0.8.1 closeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-<!-- LAST_VERIFIED: c978e74 -->
+<!-- LAST_VERIFIED: 3d44e0a -->
 
 All notable changes to this project will be documented in this file.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PipelineHealer
 
-<!-- LAST_VERIFIED: c978e74 -->
+<!-- LAST_VERIFIED: 3d44e0a -->
 
 > OSS-first, policy-aware remediation for failed CI/CD pipelines.
 
@@ -28,8 +28,8 @@ Native ingress is GitHub Actions. Jenkins is supported through the signed bridge
 - Model providers: Azure OpenAI, OpenAI-compatible, Codex App Server, custom scaffold
 - Storage: PostgreSQL, Cosmos DB, in-memory local mode
 - Secret stores: Infisical, encrypted DB, optional Azure Key Vault
-- Current release candidate: `v0.8.1`
-- Latest published release: [`v0.8.0`](https://github.com/Canepro/pipelinehealer/releases/tag/v0.8.0) until the reviewed `v0.8.1` tag is pushed
+- Current production release: `v0.8.1`
+- Latest published release: [`v0.8.1`](https://github.com/Canepro/pipelinehealer/releases/tag/v0.8.1)
 
 ## Core Workflow
 

--- a/docs/runbooks/PRODUCTION_PROMOTION_RUNBOOK.md
+++ b/docs/runbooks/PRODUCTION_PROMOTION_RUNBOOK.md
@@ -1,6 +1,6 @@
 # Production Promotion Runbook
 
-<!-- LAST_VERIFIED: c978e74 -->
+<!-- LAST_VERIFIED: 3d44e0a -->
 
 This runbook promotes a reviewed PipelineHealer release to the production Azure Container Apps lane for `pipelinehealer.canepro.me` and `api.pipelinehealer.canepro.me`.
 

--- a/reports/2026-05-31-prod-v0.8.1-closeout.html
+++ b/reports/2026-05-31-prod-v0.8.1-closeout.html
@@ -1,0 +1,293 @@
+<!doctype html>
+<!-- Codex HTML Report Template v0.5.0 adapted for PipelineHealer production cutover closeout. -->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>PipelineHealer Production Cutover Closeout</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0b0d11;
+      --bg-tint: #0f1117;
+      --surface-1: #15171f;
+      --surface-2: #1c1f29;
+      --surface-3: #242836;
+      --pre-bg: #090a0d;
+      --ink: #f4efe4;
+      --muted: #aab1be;
+      --soft: #868e9c;
+      --line: rgba(255, 255, 255, 0.085);
+      --line-2: rgba(255, 255, 255, 0.16);
+      --accent: #d6aa5c;
+      --accent-bright: #ecc379;
+      --accent-soft: rgba(214, 170, 92, 0.14);
+      --accent-line: rgba(214, 170, 92, 0.55);
+      --good: #87cc8b;
+      --warn: #e2b45e;
+      --bad: #e58b7d;
+      --info: #93b8df;
+      --neutral: #abb4c1;
+      --shadow: 0 18px 42px -26px rgba(0, 0, 0, 0.8), 0 2px 6px rgba(0, 0, 0, 0.35);
+      --shadow-lg: 0 44px 90px -46px rgba(0, 0, 0, 0.85);
+      --radius: 14px;
+      --radius-sm: 9px;
+      --mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+      --sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      --serif: ui-serif, "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", Georgia, serif;
+    }
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; }
+    body {
+      margin: 0;
+      color: var(--ink);
+      font-family: var(--sans);
+      font-size: 16px;
+      line-height: 1.6;
+      background:
+        radial-gradient(1100px 420px at 50% -160px, rgba(214, 170, 92, 0.10), transparent 70%),
+        linear-gradient(180deg, var(--bg-tint), var(--bg) 460px);
+    }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { color: var(--accent-bright); text-decoration: underline; text-underline-offset: 3px; }
+    .shell { width: min(1120px, 100% - 40px); margin: 0 auto; padding: 26px 0 72px; }
+    .topbar { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin-bottom: 22px; color: var(--muted); font-size: 0.9rem; }
+    .brand { display: inline-flex; align-items: center; gap: 11px; color: var(--ink); font-weight: 700; }
+    .mark { width: 30px; height: 30px; display: grid; place-items: center; border-radius: 9px; border: 1px solid var(--accent-line); background: linear-gradient(180deg, rgba(214, 170, 92, 0.22), rgba(214, 170, 92, 0.04)); color: var(--accent-bright); font-family: var(--serif); font-weight: 700; }
+    .hero { position: relative; overflow: hidden; padding: 46px 46px 40px; border: 1px solid var(--line); border-radius: var(--radius); background: radial-gradient(620px 200px at 8% -30px, rgba(214, 170, 92, 0.16), transparent 72%), linear-gradient(180deg, var(--surface-2), var(--surface-1)); box-shadow: var(--shadow-lg); }
+    .hero::after { content: ""; position: absolute; left: 46px; right: 46px; bottom: 0; height: 1px; background: linear-gradient(90deg, transparent, var(--accent-line), transparent); }
+    .kicker { margin: 0 0 18px; display: inline-flex; align-items: center; gap: 10px; color: var(--accent); font-size: 0.76rem; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase; }
+    .kicker::before { content: ""; width: 24px; height: 1px; background: var(--accent-line); }
+    h1, h2, h3 { margin: 0; }
+    h1 { max-width: 22ch; font-family: var(--serif); font-weight: 600; font-size: 2.05rem; line-height: 1.08; letter-spacing: 0; text-wrap: balance; }
+    h2 { font-size: 1.2rem; }
+    .lede { max-width: 74ch; margin: 18px 0 0; color: var(--muted); font-size: 1.08rem; line-height: 1.62; }
+    .facts { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px; margin: 16px 0 6px; }
+    .fact { position: relative; padding: 16px 16px 16px 20px; border: 1px solid var(--line); border-radius: var(--radius-sm); background: linear-gradient(180deg, rgba(255, 255, 255, 0.025), transparent), var(--surface-1); box-shadow: var(--shadow); }
+    .fact::before { content: ""; position: absolute; left: 0; top: 15px; bottom: 15px; width: 3px; border-radius: 0 3px 3px 0; background: var(--accent); opacity: 0.85; }
+    .fact .value { margin-top: 9px; font-size: 1.05rem; font-weight: 650; line-height: 1.3; }
+    .label, .eyebrow { font-size: 0.72rem; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; }
+    .label { color: var(--soft); }
+    .eyebrow { display: block; margin-bottom: 9px; color: var(--accent); letter-spacing: 0.14em; }
+    .status { display: inline-flex; align-items: center; gap: 7px; padding: 4px 11px 4px 9px; border: 1px solid transparent; border-radius: 999px; font-weight: 650; font-size: 0.82rem; line-height: 1.4; white-space: nowrap; }
+    .status::before { content: ""; width: 7px; height: 7px; border-radius: 50%; background: currentColor; }
+    .done { color: var(--good); background: rgba(135, 204, 139, 0.12); border-color: rgba(135, 204, 139, 0.42); }
+    .partial { color: var(--warn); background: rgba(226, 180, 94, 0.13); border-color: rgba(226, 180, 94, 0.42); }
+    .info { color: var(--info); background: rgba(147, 184, 223, 0.13); border-color: rgba(147, 184, 223, 0.42); }
+    .neutral { color: var(--neutral); background: rgba(171, 180, 193, 0.12); border-color: rgba(171, 180, 193, 0.40); }
+    nav { position: sticky; top: 0; z-index: 10; display: flex; flex-wrap: wrap; gap: 7px; margin: 20px 0 22px; padding: 10px 0; background: rgba(11, 13, 17, 0.8); backdrop-filter: blur(10px) saturate(140%); border-bottom: 1px solid var(--line); }
+    nav a { padding: 7px 13px; border: 1px solid var(--line); border-radius: 999px; background: var(--surface-1); color: var(--muted); font-size: 0.86rem; font-weight: 600; }
+    .grid { display: grid; grid-template-columns: repeat(12, 1fr); gap: 16px; }
+    .section { grid-column: span 12; padding: 26px 28px; border: 1px solid var(--line); border-radius: var(--radius); background: linear-gradient(180deg, rgba(255, 255, 255, 0.022), transparent 140px), var(--surface-1); box-shadow: var(--shadow); }
+    .half { grid-column: span 6; }
+    .third { grid-column: span 4; }
+    .section h2 { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 12px; }
+    p { margin: 0; }
+    .section p + p { margin-top: 10px; }
+    ul { margin: 10px 0 0; padding-left: 18px; }
+    li { margin: 6px 0; }
+    table { width: 100%; border-collapse: collapse; overflow: hidden; border-radius: var(--radius-sm); border: 1px solid var(--line); }
+    th, td { padding: 11px 12px; border-bottom: 1px solid var(--line); text-align: left; vertical-align: top; }
+    th { color: var(--soft); font-size: 0.72rem; letter-spacing: 0.11em; text-transform: uppercase; background: var(--surface-2); }
+    tr:last-child td { border-bottom: 0; }
+    code, pre { font-family: var(--mono); }
+    code { color: var(--accent-bright); }
+    pre { margin: 12px 0 0; padding: 14px; overflow: auto; border-radius: var(--radius-sm); border: 1px solid var(--line); background: var(--pre-bg); color: #dfe5ee; font-size: 0.86rem; line-height: 1.55; }
+    .pill-list { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 12px; }
+    .pill { display: inline-flex; align-items: center; border: 1px solid var(--line); border-radius: 999px; padding: 5px 10px; color: var(--muted); background: var(--surface-2); font-size: 0.83rem; }
+    details { margin-top: 12px; border: 1px solid var(--line); border-radius: var(--radius-sm); background: rgba(0, 0, 0, 0.16); }
+    summary { cursor: pointer; padding: 12px 14px; color: var(--ink); font-weight: 650; }
+    details > div { padding: 0 14px 14px; }
+    .timeline { margin-top: 10px; border-left: 1px solid var(--accent-line); padding-left: 18px; }
+    .event { position: relative; margin: 0 0 16px; }
+    .event::before { content: ""; position: absolute; left: -23px; top: 6px; width: 9px; height: 9px; border-radius: 50%; background: var(--accent); }
+    .event time { display: block; color: var(--soft); font-size: 0.78rem; font-family: var(--mono); }
+    .muted { color: var(--muted); }
+    .path { word-break: break-all; font-family: var(--mono); font-size: 0.88rem; }
+    @media (max-width: 820px) {
+      .shell { width: min(100% - 24px, 1120px); }
+      .hero { padding: 30px 24px; }
+      .facts { grid-template-columns: 1fr; }
+      .half, .third { grid-column: span 12; }
+      table { display: block; overflow-x: auto; }
+    }
+  </style>
+</head>
+<body>
+  <main class="shell">
+    <div class="topbar">
+      <div class="brand"><span class="mark">PH</span> PipelineHealer closeout</div>
+      <time datetime="2026-05-31">May 31, 2026</time>
+    </div>
+
+    <section class="hero">
+      <p class="kicker">Production cutover closeout</p>
+      <h1>PipelineHealer v0.8.1 is live on prod</h1>
+      <p class="lede">The production Azure Container Apps lane is deployed from the reviewed release tag, uses the existing Cosmos DB data source, injects runtime secrets from Infisical, and routes model work through Codex App Server instead of managed Azure OpenAI.</p>
+    </section>
+
+    <section class="facts">
+      <div class="fact"><span class="label">Status</span><div class="value"><span class="status done">Done</span></div></div>
+      <div class="fact"><span class="label">Release</span><div class="value">v0.8.1, commit 3d44e0a</div></div>
+      <div class="fact"><span class="label">Public app</span><div class="value">pipelinehealer.canepro.me</div></div>
+      <div class="fact"><span class="label">Model route</span><div class="value">Codex App Server, gpt-5.4</div></div>
+    </section>
+
+    <nav>
+      <a href="#outcome">Outcome</a>
+      <a href="#runtime">Runtime</a>
+      <a href="#secrets">Secrets</a>
+      <a href="#verification">Verification</a>
+      <a href="#timeline">Timeline</a>
+      <a href="#risks">Risks</a>
+    </nav>
+
+    <section class="grid">
+      <article class="section" id="outcome">
+        <span class="eyebrow">Verdict</span>
+        <h2>Prod is cut over <span class="status done">Complete</span></h2>
+        <p>PipelineHealer is live at <a href="https://pipelinehealer.canepro.me">https://pipelinehealer.canepro.me</a>, with the API at <a href="https://api.pipelinehealer.canepro.me/health">https://api.pipelinehealer.canepro.me/health</a>. The backend health check reports <code>status=healthy</code>, <code>version=0.8.1</code>, <code>environment=production</code>, and <code>storage_backend=cosmos_db</code>.</p>
+        <p>The release went through PR #182, CI, squash merge to <code>main</code>, tag <code>v0.8.1</code>, GitHub Release workflow, ACR import, Bicep deployment, ACA release promotion, domain binding, and live smoke checks.</p>
+      </article>
+
+      <article class="section half" id="runtime">
+        <span class="eyebrow">Azure Container Apps</span>
+        <h2>Production runtime</h2>
+        <table>
+          <thead><tr><th>Surface</th><th>Value</th></tr></thead>
+          <tbody>
+            <tr><td>Resource group</td><td><code>rg-canepro-ph-prod-eus2</code></td></tr>
+            <tr><td>Backend app</td><td><code>ca-canepro-ph-prod-backend</code></td></tr>
+            <tr><td>Frontend app</td><td><code>ca-canepro-ph-prod-frontend</code></td></tr>
+            <tr><td>ACR</td><td><code>caneprophacrprod01</code></td></tr>
+            <tr><td>Backend image digest</td><td><code>sha256:362bc304ef5ed10e53cfcf02da9aaff4319d3459b5734da79c2b5b3c2649fff4</code></td></tr>
+            <tr><td>Frontend image digest</td><td><code>sha256:da0f6c398e46c0adf9d71a6fe792ecfc6b638642b0fb2a79240c366582ebfdbf</code></td></tr>
+          </tbody>
+        </table>
+      </article>
+
+      <article class="section half">
+        <span class="eyebrow">Data continuity</span>
+        <h2>Previous data preserved</h2>
+        <p>The prod backend points at the existing Cosmos DB account instead of creating a replacement account.</p>
+        <table>
+          <thead><tr><th>Item</th><th>Value</th></tr></thead>
+          <tbody>
+            <tr><td>Storage mode</td><td><code>cosmos</code></td></tr>
+            <tr><td>Cosmos account</td><td><code>pipelinehealerdev-cosmos-zarrajklt3i5u</code></td></tr>
+            <tr><td>Database</td><td><code>pipelinehealer</code></td></tr>
+            <tr><td>Containers</td><td><code>activities</code>, <code>workflow_runs</code></td></tr>
+            <tr><td>Prod identity access</td><td>Cosmos DB data-plane role assignment created</td></tr>
+          </tbody>
+        </table>
+      </article>
+
+      <article class="section" id="secrets">
+        <span class="eyebrow">Infisical</span>
+        <h2>Prod secrets are injected from Infisical <span class="status done">Values redacted</span></h2>
+        <p>Infisical CLI was upgraded from <code>0.43.85</code> to <code>0.43.89</code>. Production values were staged in project <code>70ae1697-055c-4fc1-ba90-85b25f6bf138</code>, environment <code>prod</code>, path <code>/pipelinehealer/prod</code>. The deployment used <code>infisical run</code> so values were injected into child processes without printing or committing them.</p>
+        <p>The prod deploy consumed 32 Infisical-provided names. Sensitive runtime values are referenced in ACA as secret refs, including API/admin keys, GitHub tokens, webhook secrets, audit salt, settings encryption key, and the Codex App Server WebSocket bearer token.</p>
+        <details>
+          <summary>Redacted secret proof</summary>
+          <div>
+            <pre>infisical version: 0.43.89
+project: 70ae1697-055c-4fc1-ba90-85b25f6bf138
+environment: prod
+path: /pipelinehealer/prod
+injected secret names: 32
+values printed: false
+values committed: false</pre>
+          </div>
+        </details>
+      </article>
+
+      <article class="section half">
+        <span class="eyebrow">Model routing</span>
+        <h2>Codex App Server is active</h2>
+        <table>
+          <thead><tr><th>Setting</th><th>Runtime value</th></tr></thead>
+          <tbody>
+            <tr><td><code>LLM_PROVIDER</code></td><td><code>codex_app_server</code></td></tr>
+            <tr><td><code>CODEX_APP_SERVER_TRANSPORT</code></td><td><code>websocket</code></td></tr>
+            <tr><td><code>CODEX_APP_SERVER_MODEL</code></td><td><code>gpt-5.4</code></td></tr>
+            <tr><td><code>CODEX_APP_SERVER_WS_URL</code></td><td><code>wss://signalforge-codex.canepro.me</code></td></tr>
+            <tr><td><code>CODEX_APP_SERVER_WS_ALLOW_REMOTE</code></td><td><code>true</code></td></tr>
+            <tr><td>Bearer token</td><td>ACA secret ref <code>ph-be-codex-app-server-ws-bearer-token</code></td></tr>
+          </tbody>
+        </table>
+        <pre>provider-health: provider=codex_app_server, available=true, reason=ok</pre>
+      </article>
+
+      <article class="section half">
+        <span class="eyebrow">Domain</span>
+        <h2>Cloudflare and ACA custom hostnames</h2>
+        <p>Cloudflare DNS records were upserted for the app and API domains, then Azure Container Apps managed certificates were bound with SNI.</p>
+        <table>
+          <thead><tr><th>Hostname</th><th>Status</th></tr></thead>
+          <tbody>
+            <tr><td><code>pipelinehealer.canepro.me</code></td><td>CNAME to frontend ACA FQDN, cert bound, HTTP 200</td></tr>
+            <tr><td><code>api.pipelinehealer.canepro.me</code></td><td>CNAME to backend ACA FQDN, cert bound, health check healthy</td></tr>
+          </tbody>
+        </table>
+      </article>
+
+      <article class="section" id="verification">
+        <span class="eyebrow">Verification</span>
+        <h2>Checks completed</h2>
+        <table>
+          <thead><tr><th>Check</th><th>Result</th></tr></thead>
+          <tbody>
+            <tr><td>Azure Bicep build</td><td><span class="status done">Passed</span></td></tr>
+            <tr><td>Azure Bicep params build</td><td><span class="status done">Passed</span></td></tr>
+            <tr><td>Azure what-if with Infisical prod values</td><td><span class="status done">Passed</span>, no managed Azure OpenAI and no new Cosmos account</td></tr>
+            <tr><td>Version sync</td><td><span class="status done">Passed</span></td></tr>
+            <tr><td>Backend ruff, mypy, pytest</td><td><span class="status done">Passed</span>, 375 tests</td></tr>
+            <tr><td>Frontend lint, test, build</td><td><span class="status done">Passed</span>, 17 tests</td></tr>
+            <tr><td>PR #182 CI</td><td><span class="status done">Passed</span>, backend/types, frontend/build, ShellCheck, version sync</td></tr>
+            <tr><td>Release verify</td><td><span class="status done">Passed</span>, GHCR release artifacts pulled by digest</td></tr>
+            <tr><td>Prod deploy</td><td><span class="status done">Succeeded</span>, Bicep deployment and <code>deploy:release</code></td></tr>
+            <tr><td>Public smoke</td><td><span class="status done">Passed</span>, app HTTP 200, API healthy, provider health ok</td></tr>
+          </tbody>
+        </table>
+      </article>
+
+      <article class="section" id="timeline">
+        <span class="eyebrow">Timeline</span>
+        <h2>Cutover order</h2>
+        <div class="timeline">
+          <div class="event"><time>2026-05-31</time><p>Upgraded Infisical CLI to <code>0.43.89</code> and staged production secret names under <code>/pipelinehealer/prod</code>.</p></div>
+          <div class="event"><time>2026-05-31</time><p>Prepared <code>v0.8.1</code> infra changes to disable managed Azure OpenAI creation in prod, preserve existing Cosmos DB, and route through Codex App Server.</p></div>
+          <div class="event"><time>2026-05-31</time><p>Opened PR #182, waited for required checks, verified no review threads, and merged to <code>main</code>.</p></div>
+          <div class="event"><time>2026-05-31</time><p>Tagged <code>v0.8.1</code>, published the GitHub release, verified images, imported them into production ACR, and deployed ACA.</p></div>
+          <div class="event"><time>2026-05-31</time><p>Bound <code>pipelinehealer.canepro.me</code> and <code>api.pipelinehealer.canepro.me</code>, then ran live domain smoke checks.</p></div>
+        </div>
+      </article>
+
+      <article class="section" id="risks">
+        <span class="eyebrow">Residual notes</span>
+        <h2>What remains</h2>
+        <ul>
+          <li>Cloudflare records are DNS-only so Azure managed certificate validation and direct ACA host routing stay simple. Proxying can be revisited later with the usual header and TLS checks.</li>
+          <li>Agent handoff is enabled with <code>copy_only</code> mode. OpenClaw and Hermes need concrete callback/webhook endpoints before PipelineHealer can dispatch them automatically.</li>
+          <li>The frontend runtime config uses the server-side frontend proxy path. If browser-direct API calls are desired later, set <code>VITE_API_URL=https://api.pipelinehealer.canepro.me</code> during frontend build/runtime configuration.</li>
+        </ul>
+      </article>
+
+      <article class="section">
+        <span class="eyebrow">Evidence index</span>
+        <h2>Release and proof links</h2>
+        <table>
+          <thead><tr><th>Item</th><th>Reference</th></tr></thead>
+          <tbody>
+            <tr><td>Release</td><td><a href="https://github.com/Canepro/pipelinehealer/releases/tag/v0.8.1">https://github.com/Canepro/pipelinehealer/releases/tag/v0.8.1</a></td></tr>
+            <tr><td>Review PR</td><td><a href="https://github.com/Canepro/pipelinehealer/pull/182">https://github.com/Canepro/pipelinehealer/pull/182</a></td></tr>
+            <tr><td>App</td><td><a href="https://pipelinehealer.canepro.me">https://pipelinehealer.canepro.me</a></td></tr>
+            <tr><td>API health</td><td><a href="https://api.pipelinehealer.canepro.me/health">https://api.pipelinehealer.canepro.me/health</a></td></tr>
+            <tr><td>Local report file</td><td class="path">/Users/canepro/src/pipelinehealer/reports/2026-05-31-prod-v0.8.1-closeout.html</td></tr>
+          </tbody>
+        </table>
+      </article>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add the browser-native production cutover closeout for v0.8.1
- update README release status now that v0.8.1 is published and live
- refresh edited docs LAST_VERIFIED markers against the deployed 3d44e0a baseline

## Verification
- bash scripts/check_version_sync.sh
- git diff --check
- HTML parser check for reports/2026-05-31-prod-v0.8.1-closeout.html
- report-only secret-pattern scan