### PR TITLE
docs: add v0.8.5 production closeout

### DIFF
--- a/reports/2026-05-31-codex-app-server-prod-v085.html
+++ b/reports/2026-05-31-codex-app-server-prod-v085.html
@@ -1,0 +1,798 @@
+<!doctype html>
+<!-- Codex HTML Report Template v0.5.0: dark editorial report, layered surfaces, refined typography, gated status, timestamped, evidence-oriented. -->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>PipelineHealer v0.8.5 production closeout</title>
+  <style>
+    :root {
+      color-scheme: dark;
+
+      --bg: #0b0d11;
+      --bg-tint: #0f1117;
+      --surface-1: #15171f;
+      --surface-2: #1c1f29;
+      --surface-3: #242836;
+      --pre-bg: #090a0d;
+
+      --ink: #f4efe4;
+      --muted: #aab1be;
+      --soft: #868e9c;
+
+      --line: rgba(255, 255, 255, 0.085);
+      --line-2: rgba(255, 255, 255, 0.16);
+
+      --accent: #d6aa5c;
+      --accent-bright: #ecc379;
+      --accent-soft: rgba(214, 170, 92, 0.14);
+      --accent-line: rgba(214, 170, 92, 0.55);
+
+      --good: #87cc8b;
+      --warn: #e2b45e;
+      --bad: #e58b7d;
+      --info: #93b8df;
+      --neutral: #abb4c1;
+
+      --shadow: 0 18px 42px -26px rgba(0, 0, 0, 0.8), 0 2px 6px rgba(0, 0, 0, 0.35);
+      --shadow-lg: 0 44px 90px -46px rgba(0, 0, 0, 0.85);
+
+      --radius: 14px;
+      --radius-sm: 9px;
+
+      --mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+      --sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      --serif: ui-serif, "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", Georgia, serif;
+    }
+
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; }
+
+    body {
+      margin: 0;
+      color: var(--ink);
+      font-family: var(--sans);
+      font-size: 16px;
+      line-height: 1.6;
+      background:
+        radial-gradient(1100px 420px at 50% -160px, rgba(214, 170, 92, 0.10), transparent 70%),
+        linear-gradient(180deg, var(--bg-tint), var(--bg) 460px);
+    }
+
+    a { color: var(--accent); text-decoration: none; }
+    a:hover {
+      color: var(--accent-bright);
+      text-decoration: underline;
+      text-decoration-thickness: 1px;
+      text-underline-offset: 3px;
+    }
+
+    .shell {
+      width: min(1120px, 100% - 40px);
+      margin: 0 auto;
+      padding: 26px 0 72px;
+    }
+
+    .topbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      margin-bottom: 22px;
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 11px;
+      color: var(--ink);
+      font-weight: 700;
+      letter-spacing: 0.01em;
+    }
+    .mark {
+      width: 30px;
+      height: 30px;
+      display: grid;
+      place-items: center;
+      border-radius: 9px;
+      border: 1px solid var(--accent-line);
+      background: linear-gradient(180deg, rgba(214, 170, 92, 0.22), rgba(214, 170, 92, 0.04));
+      color: var(--accent-bright);
+      font-family: var(--serif);
+      font-weight: 700;
+    }
+    .topbar time { color: var(--ink); font-weight: 600; }
+
+    .hero {
+      position: relative;
+      overflow: hidden;
+      padding: 46px 46px 40px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background:
+        radial-gradient(620px 200px at 8% -30px, rgba(214, 170, 92, 0.16), transparent 72%),
+        linear-gradient(180deg, var(--surface-2), var(--surface-1));
+      box-shadow: var(--shadow-lg);
+    }
+    .hero::after {
+      content: "";
+      position: absolute;
+      left: 46px;
+      right: 46px;
+      bottom: 0;
+      height: 1px;
+      background: linear-gradient(90deg, transparent, var(--accent-line), transparent);
+    }
+    .kicker {
+      margin: 0 0 18px;
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      color: var(--accent);
+      font-size: 0.76rem;
+      font-weight: 700;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+    }
+    .kicker::before { content: ""; width: 24px; height: 1px; background: var(--accent-line); }
+
+    h1, h2, h3 { margin: 0; }
+    h1 {
+      max-width: 21ch;
+      font-family: var(--serif);
+      font-weight: 600;
+      font-size: 2.05rem;
+      line-height: 1.08;
+      letter-spacing: -0.01em;
+      text-wrap: balance;
+    }
+    .lede {
+      max-width: 66ch;
+      margin: 18px 0 0;
+      color: var(--muted);
+      font-size: 1.08rem;
+      line-height: 1.62;
+    }
+
+    .facts {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+      margin: 16px 0 6px;
+    }
+    .fact {
+      position: relative;
+      padding: 16px 16px 16px 20px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius-sm);
+      background: linear-gradient(180deg, rgba(255, 255, 255, 0.025), transparent), var(--surface-1);
+      box-shadow: var(--shadow);
+    }
+    .fact::before {
+      content: "";
+      position: absolute;
+      left: 0;
+      top: 15px;
+      bottom: 15px;
+      width: 3px;
+      border-radius: 0 3px 3px 0;
+      background: var(--accent);
+      opacity: 0.85;
+    }
+    .fact .value { margin-top: 9px; font-size: 1.05rem; font-weight: 650; line-height: 1.3; }
+
+    .label, .eyebrow {
+      font-size: 0.72rem;
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+    .label { color: var(--soft); }
+    .eyebrow { display: block; margin-bottom: 9px; color: var(--accent); letter-spacing: 0.14em; }
+
+    .status {
+      display: inline-flex;
+      align-items: center;
+      gap: 7px;
+      padding: 4px 11px 4px 9px;
+      border: 1px solid transparent;
+      border-radius: 999px;
+      font-weight: 650;
+      font-size: 0.82rem;
+      line-height: 1.4;
+      white-space: nowrap;
+    }
+    .status::before { content: ""; width: 7px; height: 7px; border-radius: 50%; background: currentColor; }
+    .done { color: var(--good); background: rgba(135, 204, 139, 0.12); border-color: rgba(135, 204, 139, 0.42); }
+    .partial { color: var(--warn); background: rgba(226, 180, 94, 0.13); border-color: rgba(226, 180, 94, 0.42); }
+    .blocked { color: var(--bad); background: rgba(229, 139, 125, 0.13); border-color: rgba(229, 139, 125, 0.42); }
+    .info { color: var(--info); background: rgba(147, 184, 223, 0.13); border-color: rgba(147, 184, 223, 0.42); }
+    .neutral { color: var(--neutral); background: rgba(171, 180, 193, 0.12); border-color: rgba(171, 180, 193, 0.40); }
+
+    nav {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 7px;
+      margin: 20px 0 22px;
+      padding: 10px 0;
+      background: rgba(11, 13, 17, 0.8);
+      backdrop-filter: blur(10px) saturate(140%);
+      border-bottom: 1px solid var(--line);
+    }
+    nav a {
+      padding: 7px 13px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--surface-1);
+      color: var(--muted);
+      font-size: 0.86rem;
+      font-weight: 600;
+    }
+    nav a:hover, nav a:focus-visible {
+      color: var(--ink);
+      border-color: var(--accent-line);
+      background: var(--surface-2);
+      text-decoration: none;
+    }
+
+    .grid { display: grid; grid-template-columns: repeat(12, 1fr); gap: 16px; }
+    .section {
+      grid-column: span 12;
+      padding: 26px 28px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: linear-gradient(180deg, rgba(255, 255, 255, 0.022), transparent 140px), var(--surface-1);
+      box-shadow: var(--shadow);
+      scroll-margin-top: 82px;
+    }
+    .span-7 { grid-column: span 7; }
+    .span-6 { grid-column: span 6; }
+    .span-5 { grid-column: span 5; }
+
+    .section-head {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 16px;
+      margin-bottom: 18px;
+    }
+
+    h2 {
+      font-family: var(--serif);
+      font-weight: 600;
+      font-size: 1.4rem;
+      line-height: 1.16;
+      letter-spacing: -0.005em;
+    }
+    h3 { font-size: 0.96rem; font-weight: 700; }
+
+    .section p { margin: 0; color: var(--muted); }
+    .section p + p { margin-top: 12px; }
+    .section > p, .section .table-wrap, .section .cards, .section .timeline { margin-top: 16px; }
+
+    .cards { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 14px; }
+    .card {
+      padding: 18px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius-sm);
+      background: var(--surface-2);
+    }
+    .card strong { display: block; margin-bottom: 8px; font-size: 0.95rem; color: var(--ink); }
+    .card p { font-size: 0.95rem; }
+
+    .table-wrap {
+      width: 100%;
+      overflow-x: auto;
+      border: 1px solid var(--line);
+      border-radius: var(--radius-sm);
+      background: var(--surface-1);
+    }
+    table { width: 100%; border-collapse: collapse; font-size: 0.92rem; }
+    th, td { padding: 12px 14px; text-align: left; vertical-align: top; border-bottom: 1px solid var(--line); }
+    th {
+      background: var(--surface-2);
+      color: var(--soft);
+      font-size: 0.71rem;
+      font-weight: 700;
+      letter-spacing: 0.09em;
+      text-transform: uppercase;
+    }
+    td:first-child { color: var(--ink); font-weight: 550; }
+    tbody tr:last-child td { border-bottom: 0; }
+    tbody tr:hover td { background: rgba(255, 255, 255, 0.02); }
+
+    code {
+      font-family: var(--mono);
+      font-size: 0.88em;
+      padding: 2px 6px;
+      border-radius: 6px;
+      background: var(--surface-2);
+      border: 1px solid var(--line);
+      color: var(--ink);
+    }
+    code.path, code.hash { overflow-wrap: anywhere; word-break: break-word; }
+    pre {
+      margin: 0;
+      padding: 16px;
+      overflow: auto;
+      border: 1px solid var(--line);
+      border-radius: var(--radius-sm);
+      background: var(--pre-bg);
+      color: #e9efe9;
+      line-height: 1.55;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+    }
+    pre code { padding: 0; border: 0; background: none; font-size: 0.86rem; color: inherit; }
+
+    .timeline { display: grid; gap: 0; }
+    .event {
+      display: grid;
+      grid-template-columns: 142px minmax(0, 1fr);
+      gap: 18px;
+      padding: 16px 0;
+      border-top: 1px solid var(--line);
+    }
+    .event:first-child { border-top: 0; padding-top: 2px; }
+    .time { color: var(--muted); font-family: var(--mono); font-size: 0.82rem; }
+    .time time { display: block; color: var(--ink); font-weight: 650; }
+    .time span { display: block; margin-top: 3px; color: var(--soft); }
+    .event-body { position: relative; padding-left: 24px; }
+    .event-body::before {
+      content: "";
+      position: absolute;
+      left: 0;
+      top: 6px;
+      width: 9px;
+      height: 9px;
+      border-radius: 50%;
+      background: var(--accent);
+      box-shadow: 0 0 0 4px var(--accent-soft);
+    }
+    .event-body::after {
+      content: "";
+      position: absolute;
+      left: 4px;
+      top: 19px;
+      bottom: -32px;
+      width: 1px;
+      background: var(--line-2);
+    }
+    .event:last-child .event-body::after { display: none; }
+
+    details {
+      margin-top: 14px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius-sm);
+      background: var(--surface-1);
+      overflow: hidden;
+    }
+    details + details { margin-top: 10px; }
+    summary {
+      cursor: pointer;
+      list-style: none;
+      padding: 14px 16px;
+      font-weight: 650;
+      color: var(--ink);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+    }
+    summary:hover { background: var(--surface-2); }
+    summary::-webkit-details-marker { display: none; }
+    summary::after { content: "+"; color: var(--accent); font-size: 1.15rem; font-weight: 700; line-height: 1; }
+    details[open] summary { border-bottom: 1px solid var(--line); }
+    details[open] summary::after { content: "\2212"; }
+    .details-body { padding: 14px 16px 16px; color: var(--muted); }
+    .details-body ul { margin: 0; padding-left: 18px; }
+    .details-body li { margin: 4px 0; }
+    .details-body pre { margin-top: 0; }
+
+    .footer {
+      margin-top: 26px;
+      padding-top: 18px;
+      border-top: 1px solid var(--line);
+      color: var(--soft);
+      font-size: 0.88rem;
+    }
+
+    @media (max-width: 920px) {
+      .facts { grid-template-columns: repeat(2, 1fr); }
+    }
+    @media (max-width: 720px) {
+      .shell { width: min(100% - 24px, 1120px); padding-top: 18px; }
+      .hero { padding: 28px 22px 26px; }
+      .hero::after { left: 22px; right: 22px; }
+      .grid { grid-template-columns: 1fr; }
+      .cards { grid-template-columns: 1fr; }
+      .facts { grid-template-columns: 1fr; }
+      .section { padding: 20px 18px; }
+      .event { grid-template-columns: 1fr; gap: 4px; }
+      .event-body { padding-left: 0; }
+      .event-body::before, .event-body::after { display: none; }
+      .topbar { flex-direction: column; align-items: flex-start; gap: 6px; }
+      table { min-width: 560px; }
+    }
+    @media (min-width: 721px) { h1 { font-size: 2.6rem; } h2 { font-size: 1.5rem; } }
+    @media (min-width: 1080px) { h1 { font-size: 3.05rem; } }
+
+    @media print {
+      body { background: #fff; color: #111; }
+      nav { display: none; }
+      .topbar, .hero, .fact, .section, .card, .table-wrap, table, details, summary {
+        background: #fff !important;
+        color: #111;
+        box-shadow: none;
+        border-color: #ddd;
+      }
+      a { color: #1a4f8f; }
+      .kicker, .eyebrow { color: #8a6d2f; }
+      h1, h2, h3, .brand, .topbar time, td:first-child, .event-body strong, summary { color: #111; }
+      .label, .lede, .section p, .details-body, .footer, .time, .time span, .card p, .value { color: #444; }
+      th { background: #f3f3f3 !important; color: #333; }
+      code { background: #f1f1f1; color: #111; border-color: #ddd; }
+      pre { background: #f6f6f6 !important; color: #111 !important; border-color: #ddd; }
+      .hero::after, .event-body::after { display: none; }
+      details { break-inside: avoid; }
+      .status { border: 1px solid #999; background: #fff; }
+    }
+  </style>
+</head>
+<body>
+  <main class="shell">
+    <header class="topbar">
+      <div class="brand"><span class="mark" aria-hidden="true">C</span> Codex</div>
+      <div>Generated <time datetime="2026-05-31">2026-05-31</time></div>
+    </header>
+
+    <section class="hero" aria-labelledby="report-title">
+      <p class="kicker">Proof report</p>
+      <h1 id="report-title">PipelineHealer implementation and deployment closeout</h1>
+      <p class="lede">Production is running PipelineHealer v0.8.5 with current Codex App Server model routing aligned to provider-specific settings, and deployment artifacts match the release and digest evidence. This report captures implementation, release, and operational proof, plus known residual risk.</p>
+    </section>
+
+    <section class="facts" aria-label="Report summary">
+      <div class="fact">
+        <div class="label">Overall status</div>
+        <div class="value"><span class="status done">Closed</span></div>
+      </div>
+      <div class="fact">
+        <div class="label">Version</div>
+        <div class="value">v0.8.5</div>
+      </div>
+      <div class="fact">
+        <div class="label">Environment</div>
+        <div class="value">production</div>
+      </div>
+      <div class="fact">
+        <div class="label">Next action</div>
+        <div class="value">Monitor first full remediations under codex_app_server</div>
+      </div>
+    </section>
+
+    <nav aria-label="Report sections">
+      <a href="#outcome">Outcome</a>
+      <a href="#next-action">Next</a>
+      <a href="#gates">Gates</a>
+      <a href="#changes">Changes</a>
+      <a href="#verification">Verification</a>
+      <a href="#timeline">Timeline</a>
+      <a href="#risks">Risks</a>
+      <a href="#evidence">Evidence</a>
+    </nav>
+
+    <div class="grid">
+      <section class="section span-7" id="outcome">
+        <div class="section-head">
+          <div>
+            <span class="eyebrow">Outcome</span>
+            <h2>Implementation and deployment outcome</h2>
+          </div>
+          <span class="status done">Implemented</span>
+        </div>
+        <p>PipelineHealer production is on v0.8.5, with Cosmos DB data preserved. Public health check confirmed production identity and healthy runtime state for service <code>PipelineHealer</code> at version <code>0.8.5</code>.</p>
+        <p>The root cause for Activity page failures was isolated to historical failed rows from external repos. Those rows came from API 401 on historical runs and are not current routing failures.</p>
+        <p>Codex App Server routing now uses provider-specific configuration only, and settings now expose and lock correct model defaults in UI and control surfaces. Provider and deployment health is good for <code>codex_app_server</code>.</p>
+      </section>
+
+      <section class="section span-5" id="next-action">
+        <span class="eyebrow">Recommended next action</span>
+        <h2>Best next move</h2>
+        <p>Run one scheduled diagnosis and one remediation pass after release lock-in. Use the resulting new Activity rows as fresh model-routing evidence that the runtime is applying <code>gpt-5.4</code>.</p>
+      </section>
+
+      <section class="section" id="gates">
+        <span class="eyebrow">Gate checklist</span>
+        <h2>Readiness before handoff closure</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Gate</th>
+                <th>Current state</th>
+                <th>Required proof</th>
+                <th>Stop condition</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Release alignment</td>
+                <td><span class="status done">Satisfied</span></td>
+                <td>Tag <code>v0.8.5</code>, passed release workflow, GHCR digest verification.</td>
+                <td>Tag, workflow, or artifact mismatch.</td>
+              </tr>
+              <tr>
+                <td>Runtime proof</td>
+                <td><span class="status done">Satisfied</span></td>
+                <td><code>/health</code>, <code>/api/settings</code>, <code>/api/settings/llm/provider-health</code>.</td>
+                <td>Any endpoint regresses from expected provider or storage values.</td>
+              </tr>
+              <tr>
+                <td>Auth model</td>
+                <td><span class="status done">Satisfied</span></td>
+                <td>Unauthenticated stats endpoint returns 401.</td>
+                <td>Anonymous access returns data.</td>
+              </tr>
+              <tr>
+                <td>Activity signal quality</td>
+                <td><span class="status partial">Pending refresh</span></td>
+                <td>Fresh remediation/diagnosis rows for current provider routing.</td>
+                <td>Persisting old 401-based failed rows as only signal.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="section" id="changes">
+        <span class="eyebrow">Changes</span>
+        <h2>What changed</h2>
+        <div class="cards">
+          <article class="card">
+            <strong>Runtime/model routing</strong>
+            <p>Backend now resolves Codex App Server tasks only through <code>CODEX_APP_SERVER_MODEL</code>. Generic task overrides for other models are ignored for <code>codex_app_server</code> capability matching.</p>
+          </article>
+          <article class="card">
+            <strong>UI and control center</strong>
+            <p>Settings and Control Center now clear/disable Codex App Server task model overrides and surface defaults as <code>gpt-5.4</code> / <code>codex app-server</code> to prevent mismatch.</p>
+          </article>
+          <article class="card">
+            <strong>Deployment and release state</strong>
+            <p>Production backend/front-end revisions moved to v0.8.5 digests and the release run for <code>v0.8.5</code> passed. PR #186 was merged and review threads were resolved.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section span-6" id="verification">
+        <span class="eyebrow">Verification</span>
+        <h2>Checks run</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Check</th>
+                <th>Result</th>
+                <th>Notes</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>bash scripts/check_version_sync.sh</code></td>
+                <td><span class="status done">Passed</span></td>
+                <td>Version sync validation completed.</td>
+              </tr>
+              <tr>
+                <td><code>git diff --check</code></td>
+                <td><span class="status done">Passed</span></td>
+                <td>Whitespace and merge conflict markers clean.</td>
+              </tr>
+              <tr>
+                <td>Backend unit/quality checks</td>
+                <td><span class="status done">Passed</span></td>
+                <td>pytest targeted 29, ruff, mypy.</td>
+              </tr>
+              <tr>
+                <td>Frontend checks</td>
+                <td><span class="status done">Passed</span></td>
+                <td>frontend lint, vitest 17 tests, build.</td>
+              </tr>
+              <tr>
+                <td>Infra check</td>
+                <td><span class="status done">Passed</span></td>
+                <td>az bicep build.</td>
+              </tr>
+              <tr>
+                <td>Production API checks</td>
+                <td><span class="status done">Passed</span></td>
+                <td><code>/health</code>, <code>/api/settings</code>, provider health, auth-protection checks and smoke calls.</td>
+              </tr>
+              <tr>
+                <td>Release check</td>
+                <td><span class="status done">Passed</span></td>
+                <td>Release workflow success, release tag and GHCR digest pullability verified.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="section span-6" id="timeline">
+        <span class="eyebrow">Timeline</span>
+        <h2>Work sequence</h2>
+        <div class="timeline">
+          <div class="event">
+            <div class="time"><time datetime="2026-05-31T04:46:57Z">04:46 UTC</time><span>PR merge</span></div>
+            <div class="event-body"><strong>Implementation merged.</strong><p>PR #186 merged at <code>2026-05-31T04:46:57Z</code> with merge commit <code>b7ae02dd15db00d6844acbde6e8a6cf67a9c5c9a</code>.</p></div>
+          </div>
+          <div class="event">
+            <div class="time"><time datetime="2026-05-31T00:00:00Z">2026-05-31</time><span>Release workflow</span></div>
+            <div class="event-body"><strong>Release validated.</strong><p>Release run <a href="https://github.com/Canepro/pipelinehealer/actions/runs/26703458776">26703458776</a> passed and release <code>v0.8.5</code> was verified with backend and frontend digests.</p></div>
+          </div>
+          <div class="event">
+            <div class="time"><time datetime="2026-05-31T00:00:00Z">2026-05-31</time><span>Deployment verification</span></div>
+            <div class="event-body"><strong>Production checks complete.</strong><p>ACA backend and frontend revisions were matched to expected digests, and deploy script health + admin settings checks were reported passed.</p></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="risks">
+        <span class="eyebrow">Risks</span>
+        <h2>Residual uncertainty</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Risk</th>
+                <th>Impact</th>
+                <th>Mitigation / next step</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Old failed Activity records remain in Cosmos</td>
+                <td>Medium, historical signal noise</td>
+                <td>Retain historical entries and rely on next diagnosis/remediation run for fresh activity tied to current model routing.</td>
+              </tr>
+              <tr>
+                <td>Provider health has no recent live routing evidence yet</td>
+                <td>Low to medium, visibility gap</td>
+                <td>Run one production diagnosis/remediation cycle and compare new rows.</td>
+              </tr>
+              <tr>
+                <td>Copilot review bot did not review</td>
+                <td>Low operational risk</td>
+                <td>Codex review threads were addressed and resolved; continue standard human/code review flow.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="section" id="evidence">
+        <span class="eyebrow">Evidence</span>
+        <h2>Proof rail</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Claim</th>
+                <th>Evidence</th>
+                <th>Result</th>
+                <th>Raw block</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Production running v0.8.5</td>
+                <td>Health endpoint and release artifacts</td>
+                <td><span class="status done">Verified</span></td>
+                <td>health + digests</td>
+              </tr>
+              <tr>
+                <td>Activity failures were historical and caused by external repo 401s</td>
+                <td>Canepro/portfolio_website-main and Canepro/pipelinehealer-demo historical rows; Github actions jobs endpoint 401s</td>
+                <td><span class="status done">Verified</span></td>
+                <td>root-cause notes</td>
+              </tr>
+              <tr>
+                <td>Prod token refresh and smoke checks are good</td>
+                <td>github_user status 200, portfolio_jobs 200 with jobs=1, demo_jobs 200 with jobs=6</td>
+                <td><span class="status done">Verified</span></td>
+                <td>redacted smoke output</td>
+              </tr>
+              <tr>
+                <td>Provider is healthy and routed to codex_app_server</td>
+                <td><code>/api/settings/llm/provider-health</code></td>
+                <td><span class="status done">Verified</span></td>
+                <td>provider ready, available=true, endpoint wss://signalforge-codex.canepro.me</td>
+              </tr>
+              <tr>
+                <td>Auth is enforced for stats endpoint</td>
+                <td>anonymous <code>/api/stats</code> returned 401</td>
+                <td><span class="status done">Verified</span></td>
+                <td>401 Missing credentials</td>
+              </tr>
+              <tr>
+                <td>Deploy artifacts pinned and pulled</td>
+                <td>Backend revision, frontend revision and GHCR pullability</td>
+                <td><span class="status done">Verified</span></td>
+                <td>aca revision + chart tag evidence</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <details open>
+          <summary>Facts used in this report</summary>
+          <div class="details-body">
+            <ul>
+              <li>Public health: <a href="https://api.pipelinehealer.canepro.me/health">https://api.pipelinehealer.canepro.me/health</a>.</li>
+              <li>PR: <a href="https://github.com/Canepro/pipelinehealer/pull/186">#186</a>.</li>
+              <li>Release workflow: <a href="https://github.com/Canepro/pipelinehealer/actions/runs/26703458776">26703458776</a>.</li>
+              <li>Release tag: <a href="https://github.com/Canepro/pipelinehealer/releases/tag/v0.8.5">v0.8.5</a>.</li>
+              <li>Azure model references:
+                <ul>
+                  <li><a href="https://learn.microsoft.com/azure/ai-services/openai/concepts/models">azure openai model concepts</a></li>
+                  <li><a href="https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/concepts/deployment-types?view=azure-node-latest">azure foundry deployment types</a></li>
+                </ul>
+              </li>
+            </ul>
+          </div>
+        </details>
+        <details>
+          <summary>Runtime and settings snapshots</summary>
+          <div class="details-body">
+            <pre><code>Health (expected): service PipelineHealer, version 0.8.5, status healthy, environment production, storage_backend cosmos_db.
+
+Prod /api/settings (expected key set):
+- llm_provider = codex_app_server
+- codex_app_server_model = gpt-5.4
+- llm_model_analysis = ""
+- llm_model_diagnosis = ""
+- llm_model_remediation = ""
+- storage_mode = cosmos
+- storage_backend = cosmos_db
+- github_pat_configured = true
+- auth_mode = hybrid
+
+Provider health (expected):
+- provider = codex_app_server
+- available = true
+- reason = ok
+- endpoint = wss://signalforge-codex.canepro.me
+- deployment_name = gpt-5.4
+- capability_state = provider_ready
+
+Frontend runtime-config.js (expected):
+- VITE_AUTH_MODE = entra
+- VITE_API_AUTH_KEY = "" (empty)
+- VITE_API_URL = "" (empty)
+- redirect URI = https://pipelinehealer.canepro.me/app</code></pre>
+          </div>
+        </details>
+        <details>
+          <summary>Deployment and release identifiers</summary>
+          <div class="details-body">
+            <ul>
+              <li>ACA backend revision: <code>ca-canepro-ph-prod-backend--0000008</code></li>
+              <li>Backend image digest: <code>caneprophacrprod01.azurecr.io/pipelinehealer-backend@sha256:6bed2150092c1d89b3f8d3c188ad98339addcef8348e249d021b68989505fce5</code></li>
+              <li>Frontend image digest: <code>sha256:d52e626d887d13a4e12625bfa27c76045d38335515302438c58839b3a5860d50</code></li>
+              <li>Release chart tag: <code>0.8.5</code></li>
+              <li>Release SHA: <code>259813c6673faa405acaa6c2bbd1936ff732ed3f</code></li>
+              <li>Merge commit: <code>b7ae02dd15db00d6844acbde6e8a6cf67a9c5c9a</code></li>
+              <li>Deployment checks: script-verified backend health and admin settings.</li>
+            </ul>
+          </div>
+        </details>
+      </section>
+    </div>
+
+    <footer class="footer">
+      Self-contained dark-first Codex report. No external runtime assets, fonts, scripts, or CDNs are required.
+    </footer>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add the browser-native v0.8.5 production closeout report.
- Capture release, deployment, Infisical/GitHub token smoke, Entra/auth, Cosmos continuity, Codex App Server routing, and residual risks.

## Verification
- `html.parser` parsed the report successfully.
- Self-contained HTML checks passed: doctype/title/style present, no external script/css.
- Secret scan found no raw token/key patterns.

Report path: `reports/2026-05-31-codex-app-server-prod-v085.html`