### PR TITLE
Add public-safe init bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PipelineHealer
 
-<!-- LAST_VERIFIED: 6bd38bf -->
+<!-- LAST_VERIFIED: caeed6a -->
 
 > OSS-first, policy-aware remediation for failed CI/CD pipelines.
 
@@ -59,7 +59,15 @@ Prerequisites:
 Create local env metadata:
 
 ```bash
-cp backend/.env.example backend/.env
+bash scripts/ph.sh init
+```
+
+`init` creates `backend/.env` when it is missing, generates local bootstrap secrets without printing them, defaults new installs to Codex App Server (`gpt-5.4`), and points the operator to the Settings UI for provider keys, repo scope, auto-fix policy, handoff targets, and write-only secrets.
+
+For an approved repo where PipelineHealer may create and safely merge remediation PRs after clean checks:
+
+```bash
+bash scripts/ph.sh init --auto-fix --repos owner/repo --llm-provider codex_app_server
 ```
 
 For secrets, prefer Infisical. Do not commit secret values.
@@ -75,7 +83,7 @@ Keep only metadata in `backend/.env` after migration:
 SETTINGS_SECRET_BACKEND=infisical
 INFISICAL_PROJECT_ID=<infisical-project-id>
 INFISICAL_ENVIRONMENT=dev
-INFISICAL_SECRET_PATH=/personal/pipelinehealer
+INFISICAL_SECRET_PATH=/pipelinehealer/dev
 ```
 
 Start the backend:
@@ -85,7 +93,7 @@ cd backend
 uv venv .venv
 source .venv/bin/activate
 uv pip install -e ".[dev]"
-infisical run --env dev --path /personal/pipelinehealer --projectId <infisical-project-id> -- uvicorn src.main:app --reload --port 8000
+infisical run --env dev --path /pipelinehealer/dev --projectId <infisical-project-id> -- uvicorn src.main:app --reload --port 8000
 ```
 
 Start the frontend:
@@ -119,24 +127,34 @@ Rules:
 
 Steps:
 1. Read AGENTS.md, README.md, docs/reference/CLI.md, and docs/runbooks/LOCAL_DEMO_RUNBOOK.md.
-2. Install backend deps with: cd backend && uv pip install -e ".[dev]".
-3. Install frontend deps with: cd frontend && bun install.
-4. Configure backend/.env from backend/.env.example.
+2. Run: bash scripts/ph.sh init.
+3. Install backend deps with: cd backend && uv pip install -e ".[dev]".
+4. Install frontend deps with: cd frontend && bun install.
 5. Migrate or inject secrets with Infisical. Use redacted proof only.
-6. Start backend with infisical run and uvicorn.
-7. Start frontend with bun run dev.
-8. Verify /health, /api/settings, frontend load, and at least one activity or handoff path if test data exists.
-9. Report exact commands run, pass/fail status, and any blocked secrets or provider setup.
+6. Finish model, GitHub, repo allowlist, auto-fix, handoff, and write-only secret setup in /app/settings.
+7. Start backend with infisical run and uvicorn.
+8. Start frontend with bun run dev.
+9. Verify /health, /api/settings, frontend load, and at least one activity or handoff path if test data exists.
+10. Report exact commands run, pass/fail status, and any blocked secrets or provider setup.
 ```
 
 ## Azure Container Apps Deploy
 
 The reference deployment uses `scripts/ph.sh`, Azure Container Registry, and Azure Container Apps.
 
+Set your Azure target explicitly. The public CLI does not carry maintainer production names:
+
+```bash
+export PH_RG=<resource-group>
+export PH_BACKEND_APP=<backend-container-app>
+export PH_FRONTEND_APP=<frontend-container-app>
+export PH_ACR_NAME=<container-registry-name>
+```
+
 Recommended Infisical-backed deploy:
 
 ```bash
-infisical run --env dev --path /personal/pipelinehealer --projectId <infisical-project-id> -- \
+infisical run --env dev --path /pipelinehealer/dev --projectId <infisical-project-id> -- \
   bash scripts/ph.sh deploy --secure-secrets
 ```
 
@@ -145,7 +163,7 @@ If Docker or Podman is not running locally, add `--remote-build` to build the im
 Env-only update:
 
 ```bash
-infisical run --env dev --path /personal/pipelinehealer --projectId <infisical-project-id> -- \
+infisical run --env dev --path /pipelinehealer/dev --projectId <infisical-project-id> -- \
   bash scripts/ph.sh deploy:env --secure-secrets
 ```
 
@@ -164,7 +182,7 @@ bash scripts/ph.sh logs
 
 The deploy adapter stores sensitive values as Container App secrets and binds them through `secretref`. It reads process env first, so `infisical run` can inject values without restoring them to `backend/.env`.
 
-For the production lane, follow [docs/runbooks/PRODUCTION_PROMOTION_RUNBOOK.md](docs/runbooks/PRODUCTION_PROMOTION_RUNBOOK.md). Production promotion uses reviewed release images, Infisical-injected secrets, Azure `what-if`, and the `rg-canepro-ph-prod-eus2` Container Apps lane.
+For production lanes, follow [docs/runbooks/PRODUCTION_PROMOTION_RUNBOOK.md](docs/runbooks/PRODUCTION_PROMOTION_RUNBOOK.md). Production promotion uses reviewed release images, Infisical-injected secrets, Azure `what-if`, and operator-supplied Container Apps target names.
 
 ## Kubernetes And Local Containers
 
@@ -216,6 +234,7 @@ Security policy: [SECURITY.md](SECURITY.md)
 
 ```bash
 bash scripts/ph.sh help
+bash scripts/ph.sh init
 bash scripts/ph.sh status
 bash scripts/ph.sh settings:check
 bash scripts/ph.sh deploy:release --release-version vX.Y.Z

--- a/backend/tests/test_ph_init.py
+++ b/backend/tests/test_ph_init.py
@@ -1,0 +1,212 @@
+"""Regression tests for the ph.sh init bootstrap command."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _run_init(env_file: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PH_ENV_FILE"] = str(env_file)
+    return subprocess.run(
+        ["bash", "scripts/ph.sh", "init", *args],
+        cwd=_repo_root(),
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _run_ph(*args: str, env_file: Path | None = None, extra_env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    for key in (
+        "PH_RG",
+        "PH_BACKEND_APP",
+        "PH_FRONTEND_APP",
+        "PH_ACR_NAME",
+        "ACR_NAME",
+        "PH_BACKEND_URL",
+        "DEMO_REPO",
+        "PH_FRONTEND_URL",
+    ):
+        env.pop(key, None)
+    if env_file is not None:
+        env["PH_ENV_FILE"] = str(env_file)
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        ["bash", "scripts/ph.sh", *args],
+        cwd=_repo_root(),
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _env_map(env_file: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for raw_line in env_file.read_text(encoding="utf-8").splitlines():
+        if not raw_line or raw_line.startswith("#") or "=" not in raw_line:
+            continue
+        key, value = raw_line.split("=", 1)
+        result[key] = value
+    return result
+
+
+def test_init_creates_codex_app_server_env_without_printing_generated_secrets(tmp_path: Path) -> None:
+    env_file = tmp_path / "backend.env"
+
+    result = _run_init(
+        env_file,
+        "--auto-fix",
+        "--repos",
+        "owner/demo-repo",
+        "--infisical-project-id",
+        "project-123",
+        "--infisical-env",
+        "prod",
+        "--infisical-path",
+        "/pipelinehealer/prod",
+    )
+
+    values = _env_map(env_file)
+    mode = stat.S_IMODE(env_file.stat().st_mode)
+
+    assert mode == 0o600
+    assert values["LLM_PROVIDER"] == "codex_app_server"
+    assert values["CODEX_APP_SERVER_MODEL"] == "gpt-5.4"
+    assert values["STORAGE_MODE"] == "memory"
+    assert values["AUTH_MODE"] == "api_key"
+    assert values["AUTO_CREATE_PR"] == "true"
+    assert values["AUTO_MERGE_REMEDIATION_PRS"] == "true"
+    assert values["AUTO_MERGE_STRATEGY"] == "merge_when_clean"
+    assert values["PH_ALLOWED_REPOS"] == "owner/demo-repo"
+    assert values["SETTINGS_SECRET_BACKEND"] == "infisical"
+    assert values["INFISICAL_PROJECT_ID"] == "project-123"
+    assert values["INFISICAL_ENVIRONMENT"] == "prod"
+    assert values["INFISICAL_SECRET_PATH"] == "/pipelinehealer/prod"
+
+    generated_secret_keys = (
+        "API_AUTH_KEY",
+        "ADMIN_API_KEY",
+        "AUDIT_SALT",
+        "GITHUB_WEBHOOK_SECRET",
+        "SETTINGS_DB_ENCRYPTION_KEY",
+    )
+    for key in generated_secret_keys:
+        assert values[key]
+        assert "CHANGE_ME" not in values[key]
+        assert "YOUR_" not in values[key]
+        assert values[key] not in result.stdout
+
+    assert "Created env scaffold with generated local secrets. Values were not printed." in result.stdout
+    assert "UI-first fields already supported" in result.stdout
+    assert "pipelinehealer.canepro.me" not in result.stdout
+    assert "rg-canepro" not in result.stdout
+    assert "ca-canepro" not in result.stdout
+    assert "Canepro/pipelinehealer-demo" not in result.stdout
+
+
+def test_init_leaves_existing_env_unchanged_without_force(tmp_path: Path) -> None:
+    env_file = tmp_path / "backend.env"
+    env_file.write_text(
+        "API_AUTH_KEY=keep-me\nLLM_PROVIDER=azure_openai\n",
+        encoding="utf-8",
+    )
+    env_file.chmod(0o600)
+
+    result = _run_init(env_file, "--auto-fix", "--repos", "owner/repo")
+
+    assert env_file.read_text(encoding="utf-8") == "API_AUTH_KEY=keep-me\nLLM_PROVIDER=azure_openai\n"
+    assert "Env file already exists. Leaving values unchanged." in result.stdout
+
+
+def test_demo_proof_requires_explicit_repo_when_no_env_default() -> None:
+    result = _run_ph("demo:proof")
+
+    assert result.returncode == 2
+    assert "Usage: bash scripts/ph.sh demo:proof --repo owner/repo" in result.stderr
+    assert "Canepro/pipelinehealer-demo" not in result.stderr
+
+
+def test_azure_status_requires_operator_supplied_app_names() -> None:
+    result = _run_ph("status")
+
+    assert result.returncode == 2
+    assert "needs Azure Container Apps target env vars" in result.stderr
+    assert "PH_RG" in result.stderr
+    assert "PH_BACKEND_APP" in result.stderr
+    assert "PH_FRONTEND_APP" in result.stderr
+    assert "rg-canepro" not in result.stderr
+    assert "ca-canepro" not in result.stderr
+
+
+def test_deploy_env_requires_operator_supplied_app_names() -> None:
+    result = _run_ph("deploy:env", "--no-verify")
+
+    assert result.returncode == 2
+    assert "Missing Azure deployment target configuration" in result.stderr
+    assert "--resource-group or PH_RG" in result.stderr
+    assert "--backend-app or PH_BACKEND_APP" in result.stderr
+    assert "--frontend-app or PH_FRONTEND_APP" in result.stderr
+    assert "rg-canepro" not in result.stderr
+    assert "ca-canepro" not in result.stderr
+
+
+def test_demo_e2e_requires_operator_supplied_repo_and_backend_names() -> None:
+    result = _run_ph("demo:e2e", "--skip-trigger", "--skip-webhook-sync", "--skip-reset")
+
+    assert result.returncode == 2
+    assert "Missing Azure demo target configuration" in result.stderr
+    assert "--repo or DEMO_REPO" in result.stderr
+    assert "--resource-group or PH_RG" in result.stderr
+    assert "--backend-app or PH_BACKEND_APP" in result.stderr
+    assert "Canepro/pipelinehealer-demo" not in result.stderr
+    assert "rg-canepro" not in result.stderr
+    assert "ca-canepro" not in result.stderr
+
+
+def test_azure_logs_require_operator_supplied_backend_names() -> None:
+    for command in ("logs", "logs:raw"):
+        result = _run_ph(command)
+        assert result.returncode == 2
+        assert "needs Azure backend target env vars" in result.stderr
+        assert "PH_RG" in result.stderr
+        assert "PH_BACKEND_APP" in result.stderr
+        assert "rg-canepro" not in result.stderr
+        assert "ca-canepro" not in result.stderr
+
+    grep_result = _run_ph("logs:grep", "--pattern", "error")
+    assert grep_result.returncode == 2
+    assert "needs Azure backend target env vars" in grep_result.stderr
+
+
+def test_deploy_state_commands_require_resource_group() -> None:
+    for command in ("deploy:bg", "deploy:logs", "deploy:status"):
+        result = _run_ph(command)
+        assert result.returncode == 2
+        assert "needs --resource-group or PH_RG for deploy state files" in result.stderr
+        assert "/tmp/ph-deploy-/" not in result.stderr
+        assert "/tmp/ph-deploy-/" not in result.stdout
+
+
+def test_rollout_canary_validates_azure_target_before_env_mutation(tmp_path: Path) -> None:
+    env_file = tmp_path / "backend.env"
+    original = "PH_ALLOWED_REPOS=keep/repo\nHEAL_MODE=observe\n"
+    env_file.write_text(original, encoding="utf-8")
+    env_file.chmod(0o600)
+
+    result = _run_ph("rollout:canary", "--repos", "owner/repo", env_file=env_file)
+
+    assert result.returncode == 2
+    assert "needs Azure Container Apps target env vars" in result.stderr
+    assert env_file.read_text(encoding="utf-8") == original

--- a/docs/reference/CLI.md
+++ b/docs/reference/CLI.md
@@ -1,6 +1,6 @@
 # PipelineHealer CLI Reference
 
-<!-- LAST_VERIFIED: 17c3243 -->
+<!-- LAST_VERIFIED: caeed6a -->
 
 Canonical reference for `scripts/ph.sh` — the one-command operator interface for PipelineHealer.
 
@@ -30,6 +30,9 @@ Important: execute with `bash scripts/...`, never `source` or `. scripts/...`.
 Quick examples:
 
 ```bash
+# Bootstrap local/dev env and continue setup in the UI
+bash scripts/ph.sh init
+
 # Backend API scope (local OR any reachable backend URL)
 PH_BACKEND_URL=http://127.0.0.1:8000 bash scripts/ph.sh settings:check
 
@@ -110,6 +113,43 @@ PowerShell-only environments (no bash): run the same GitHub checks with `gh`, an
 
 ## Commands
 
+### Init
+
+| Command | Description |
+|---------|-------------|
+| `init` | Bootstrap first-run env, dependency checks, Codex App Server defaults, and UI handoff |
+
+```bash
+bash scripts/ph.sh init
+bash scripts/ph.sh init --auto-fix --repos owner/repo --llm-provider codex_app_server
+bash scripts/ph.sh init --mode prod --infisical-project-id <project-id> --infisical-env prod --infisical-path /pipelinehealer/prod
+```
+
+`init` is safe to rerun. If the env file already exists, it leaves values unchanged unless `--force-env` is provided. Use `PH_ENV_FILE=/path/to/env` to target a different env file.
+
+What it does:
+- checks required local tools (`bash`, `python3`, `curl`, `git`) and reports optional tooling (`uv`, `bun`, Docker/Podman, `az`, `gh`, `infisical`)
+- creates `backend/.env` from `backend/.env.example` when missing
+- generates local bootstrap secrets for API/admin auth, audit salt, webhook signing, and encrypted DB storage without printing values
+- defaults new installs to `LLM_PROVIDER=codex_app_server` and `CODEX_APP_SERVER_MODEL=gpt-5.4`
+- can set `PH_ALLOWED_REPOS` and safe auto-merge policy with `--auto-fix --repos owner/repo`
+- can write Infisical metadata (`SETTINGS_SECRET_BACKEND=infisical`, project id, environment, path) without reading or printing secret values
+- prints local dev, local container, and production Settings UI URLs so operators can finish provider keys, GitHub access, handoff targets, and write-only secrets in the UI
+
+Flags:
+
+| Flag | Values | Description |
+|------|--------|-------------|
+| `--mode` | `local`, `azure`, `prod`, `production` | Select local or production-oriented bootstrap defaults |
+| `--llm-provider` | `azure_openai`, `openai_compatible`, `codex_app_server`, `custom` | Initial model provider |
+| `--repos` | CSV | Initial `PH_ALLOWED_REPOS` value |
+| `--auto-fix` | — | Enables PR creation and `merge_when_clean` auto-merge policy in the generated env |
+| `--infisical-project-id` | string | Writes Infisical project metadata only |
+| `--infisical-env` | string | Infisical environment metadata, default `dev` |
+| `--infisical-path` | string | Infisical secret path metadata, default `/pipelinehealer/dev` |
+| `--force-env` | — | Recreate the env file from the template |
+| `--skip-env` | — | Run checks and print next steps without writing env |
+
 ### Deploy
 
 | Command | Description |
@@ -139,6 +179,15 @@ bash scripts/ph.sh deploy --engine podman
 bash scripts/ph.sh deploy --acr-retain-tags 50
 bash scripts/ph.sh deploy --skip-acr-prune
 bash scripts/ph.sh deploy --skip-local-image-prune
+```
+
+Azure-only deploy commands require the target to be supplied through flags or environment variables. The public CLI has no maintainer production defaults:
+
+```bash
+export PH_RG=<resource-group>
+export PH_BACKEND_APP=<backend-container-app>
+export PH_FRONTEND_APP=<frontend-container-app>
+export PH_ACR_NAME=<container-registry-name>
 ```
 
 Important:
@@ -206,15 +255,16 @@ bash scripts/ph.sh rollout:canary --repos owner/repo1,owner/repo2 --skip-env-syn
 | `demo:reset` | Reset demo fixture repo for dependency/lint failures |
 
 ```bash
-bash scripts/ph.sh demo:e2e
-bash scripts/ph.sh demo:e2e --skip-webhook-sync
-bash scripts/ph.sh demo:e2e --triggers dependency,lint,test --wait-seconds 180
-bash scripts/ph.sh demo:e2e --triggers dependency,lint,test,build_config,timeout --wait-seconds 180 --ci-signal-wait-seconds 180 --strict
+bash scripts/ph.sh demo:e2e --repo owner/repo
+bash scripts/ph.sh demo:e2e --repo owner/repo --skip-webhook-sync
+bash scripts/ph.sh demo:e2e --repo owner/repo --triggers dependency,lint,test --wait-seconds 180
+bash scripts/ph.sh demo:e2e --repo owner/repo --triggers dependency,lint,test,build_config,timeout --wait-seconds 180 --ci-signal-wait-seconds 180 --strict
 bash scripts/ph.sh demo:proof --repo owner/repo --limit 10
 bash scripts/ph.sh demo:reset
 ```
 
 `demo:e2e` notes:
+- It requires `--repo owner/repo` or `DEMO_REPO=owner/repo`, plus the same Azure backend target variables used by `status`/`urls`.
 - Default activity settle wait is now `180s` (override with `--wait-seconds <n>`).
 - It performs a best-effort on-demand diagnostics backfill before final activity summary (disable with `--skip-backfill`).
 - It checks for at least one CI doctor-style workflow signal after dispatch (`CI Failure Doctor`/`ci-doctor`) using `--ci-signal-wait-seconds <n>`; queued/in-progress/completed runs all count as signal observed.
@@ -250,12 +300,14 @@ bash scripts/ph.sh urls
 bash scripts/ph.sh status
 ```
 
+`urls`, `status`, `warm`, and `lowcost` require `PH_RG`, `PH_BACKEND_APP`, and `PH_FRONTEND_APP`.
+
 Infisical-backed ACA deploys can inject values into the deploy process and keep `backend/.env` value-free:
 
 ```bash
-infisical run --env dev --path /personal/pipelinehealer --projectId <infisical-project-id> -- \
+infisical run --env dev --path /pipelinehealer/dev --projectId <infisical-project-id> -- \
   bash scripts/ph.sh deploy --secure-secrets
-infisical run --env dev --path /personal/pipelinehealer --projectId <infisical-project-id> -- \
+infisical run --env dev --path /pipelinehealer/dev --projectId <infisical-project-id> -- \
   bash scripts/ph.sh deploy:env --secure-secrets
 ```
 
@@ -507,7 +559,7 @@ The same action is available in the UI via the "Backfill Diagnostics" button on 
 ## Error Handling
 
 - **Missing flag values**: All `--flag value` arguments are guarded by `require_arg`. Running `--repo` without a value produces `Error: --repo requires a value argument.` (exit 2) instead of a shell crash.
-- **`demo:proof` repo fallback**: `demo:proof` defaults to `${DEMO_REPO}` when exported, otherwise `Canepro/pipelinehealer-demo`. If `--repo` is passed with an empty shell expansion (for example `--repo "$DEMO_REPO"` when `DEMO_REPO` is unset), the command warns and falls back to that default repo.
+- **`demo:proof` repo selection**: `demo:proof` requires `--repo owner/repo` or an exported `DEMO_REPO=owner/repo`. If `--repo` is missing or empty, the command exits 2 instead of assuming a maintainer demo repo.
 - **Unknown arguments**: Unrecognized flags produce a clear message and exit 2.
 - **Enum validation**: `--heal-mode`, `--auto-apply-remediation`, `--auto-create-pr`, `--auto-create-issue`, `--auto-retry-workflow`, `--gh-aw-tools-enabled`, `--gh-aw-ingestion-mode`, and `--mcp-provider` validate against allowed values before proceeding.
 - **Strict mode**: `set -euo pipefail` is enabled throughout. Log grep pipelines use `|| true` to remain tolerant of empty results.
@@ -574,9 +626,10 @@ unset PH_BACKEND_URL
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `PH_BACKEND_URL` | *(unset — Azure mode)* | Set to target a local backend (for example `http://127.0.0.1:8000`) |
-| `PH_RG` | `rg-canepro-ph-dev-eus` | Azure resource group |
-| `PH_BACKEND_APP` | `ca-canepro-ph-backend` | Backend Container App name |
-| `PH_FRONTEND_APP` | `ca-canepro-ph-frontend` | Frontend Container App name |
+| `PH_RG` | *(unset)* | Azure resource group for Azure-only commands |
+| `PH_BACKEND_APP` | *(unset)* | Backend Container App name for Azure-only commands |
+| `PH_FRONTEND_APP` | *(unset)* | Frontend Container App name for Azure-only commands |
+| `PH_ACR_NAME` / `ACR_NAME` | *(unset)* | Azure Container Registry name for full/release deploys |
 | `PH_DEPLOY_LOG` | `/tmp/ph-deploy-<rg>/redeploy.log` | Background deploy log path |
 | `PH_DEPLOY_PID` | `/tmp/ph-deploy-<rg>/redeploy.pid` | Background deploy PID path |
 

--- a/docs/runbooks/DEMO_SCRIPT.md
+++ b/docs/runbooks/DEMO_SCRIPT.md
@@ -1,6 +1,6 @@
 # PipelineHealer Demo Recording Guide (Single-File Runbook)
 
-<!-- LAST_VERIFIED: 2c862a3 -->
+<!-- LAST_VERIFIED: caeed6a -->
 
 Use this as the only doc during recording day. It includes:
 
@@ -33,15 +33,19 @@ This runbook aligns to the submission checklist in `docs/HACKATHON_LOG.md`:
 
 Remaining submission item this doc drives: demo video length must be 2:00 max.
 
-Default values used in this runbook:
+Required shell values used in this runbook:
 
 ```bash
 export RELEASE_TAG="${RELEASE_TAG:-$(git describe --tags --abbrev=0 2>/dev/null || echo v0.7.2)}"
-export DEMO_REPO="${DEMO_REPO:-Canepro/pipelinehealer-demo}"
+export DEMO_REPO="${DEMO_REPO:?set DEMO_REPO=owner/repo for your demo fixture repo}"
+export PH_RG="${PH_RG:?set PH_RG to your Azure resource group}"
+export PH_BACKEND_APP="${PH_BACKEND_APP:?set PH_BACKEND_APP to your backend Container App}"
+export PH_FRONTEND_APP="${PH_FRONTEND_APP:?set PH_FRONTEND_APP to your frontend Container App}"
+export PH_ACR_NAME="${PH_ACR_NAME:?set PH_ACR_NAME to your Azure Container Registry}"
 ```
 
 Keep `RELEASE_TAG` pinned to the latest published tag for recording. The default above resolves to the latest local tag when available and falls back to `v0.7.2` (the latest published release) if tags have not been fetched yet, so the demo never targets an unpublished tag whose release images do not exist. Run `git fetch --tags` first if you want the newest published tag picked up automatically. Do not point the demo flow at an untagged local branch or unreleased commit.
-If `DEMO_REPO` is not exported in your shell, either run the export block above first or omit `--repo` and let `bash scripts/ph.sh demo:proof` fall back to the default demo repo.
+`DEMO_REPO` must be explicit. The public CLI does not fall back to a maintainer demo repository.
 
 ## Recording Plan (2 Minutes Max)
 

--- a/docs/runbooks/LOCAL_DEMO_RUNBOOK.md
+++ b/docs/runbooks/LOCAL_DEMO_RUNBOOK.md
@@ -1,6 +1,6 @@
 # Local Demo Runbook (PipelineHealer)
 
-<!-- LAST_VERIFIED: 8817b54 -->
+<!-- LAST_VERIFIED: caeed6a -->
 
 This guide walks you through setting up PipelineHealer locally, triggering CI failures in a demo repo, and verifying the results on the dashboard.
 
@@ -16,7 +16,7 @@ For dedicated feature-by-feature docs, see `docs/features/README.md`.
 
 Use this path if you are new and want the least setup friction:
 
-1. Copy env template: `cp backend/.env.example backend/.env`
+1. Bootstrap env metadata: `bash scripts/ph.sh init`
 2. Fill only required values:
    - one LLM path (`AZURE_OPENAI_*` or `OPENAI_COMPATIBLE_*`)
    - `GITHUB_PERSONAL_ACCESS_TOKEN`
@@ -46,19 +46,20 @@ After migration, keep only Infisical metadata in `backend/.env`:
 SETTINGS_SECRET_BACKEND=infisical
 INFISICAL_PROJECT_ID=<infisical-project-id>
 INFISICAL_ENVIRONMENT=dev
-INFISICAL_SECRET_PATH=/personal/pipelinehealer
+INFISICAL_SECRET_PATH=/pipelinehealer/dev
 ```
 
 If bootstrap values such as `API_AUTH_KEY`, `ADMIN_API_KEY`, or `AUDIT_SALT` were migrated too, start local commands through Infisical:
 
 ```bash
-infisical run --env dev --path /personal/pipelinehealer --projectId <infisical-project-id> -- <command>
+infisical run --env dev --path /pipelinehealer/dev --projectId <infisical-project-id> -- <command>
 ```
 
 For Azure Container Apps, use the same process-injection pattern with secret refs:
 
 ```bash
-infisical run --env dev --path /personal/pipelinehealer --projectId <infisical-project-id> -- \
+PH_RG=<resource-group> PH_BACKEND_APP=<backend-app> PH_FRONTEND_APP=<frontend-app> PH_ACR_NAME=<acr-name> \
+infisical run --env dev --path /pipelinehealer/dev --projectId <infisical-project-id> -- \
   bash scripts/ph.sh deploy --secure-secrets
 ```
 
@@ -588,7 +589,7 @@ If your backend is running on a remote VM or cluster and `127.0.0.1:8000` only e
    - **Events**: select **Let me select individual events** → check only **Workflow runs**
    - Click **Add webhook**
 
-> **Tip:** You can use the included demo repo at `Canepro/pipelinehealer-demo`, or set up your own repo using the fixtures in the `demo-repo/` folder.
+> **Tip:** Set up a demo repo using the fixtures in the `demo-repo/` folder, then pass it explicitly with `--repo owner/repo`.
 
 ---
 
@@ -602,7 +603,7 @@ gh workflow run ci.yml -R <owner>/<repo> -f failure_type=dependency
 gh workflow run ci.yml -R <owner>/<repo> -f failure_type=lint
 ```
 
-Replace `<owner>/<repo>` with your demo repo (for example `Canepro/pipelinehealer-demo`).
+Replace `<owner>/<repo>` with your demo repo.
 If the workflow filename is not `ci.yml` in your repo, use the name returned by `gh workflow list`.
 
 For an approved end-to-end auto-fix demo, enable `AUTO_CREATE_PR=true` and `AUTO_MERGE_REMEDIATION_PRS=true` for a narrow `PH_ALLOWED_REPOS` list. Keep `AUTO_MERGE_REQUIRE_CLEAN_CHECKS=true`; PipelineHealer records the PR URL, merge strategy, check summary, optional ignored app-check failures, and merge result in the Activity remediation details.

--- a/docs/runbooks/PREDEPLOY_PLACEHOLDER_AUDIT.md
+++ b/docs/runbooks/PREDEPLOY_PLACEHOLDER_AUDIT.md
@@ -1,6 +1,6 @@
 # Pre-Deploy Placeholder Audit
 
-<!-- LAST_VERIFIED: 044aa39 -->
+<!-- LAST_VERIFIED: caeed6a -->
 
 Use this checklist before `azd up`, before major public demos, and before final submission recording.
 
@@ -100,8 +100,8 @@ curl -sS http://127.0.0.1:8000/health
 curl -sS -H "X-API-Key: $API_AUTH_KEY" "http://127.0.0.1:8000/api/activities?limit=20"
 
 # Open remediation outputs in demo repo
-gh pr list -R Canepro/pipelinehealer-demo
-gh issue list -R Canepro/pipelinehealer-demo --state open
+gh pr list -R owner/demo-repo
+gh issue list -R owner/demo-repo --state open
 ```
 
 ## 8) Sign-Off
@@ -119,9 +119,9 @@ Mark this audit complete when all stop-ship checks pass:
 
 Applied environment:
 
-- Resource group: `rg-canepro-ph-dev-eus`
-- Backend app: `ca-canepro-ph-backend`
-- Frontend app: `ca-canepro-ph-frontend`
+- Resource group: operator-supplied `PH_RG`
+- Backend app: operator-supplied `PH_BACKEND_APP`
+- Frontend app: operator-supplied `PH_FRONTEND_APP`
 - Azure OpenAI deployment: operator-owned deployment name
 - Backend mode: `ENVIRONMENT=production`
 - Heal mode: `safe`

--- a/docs/runbooks/PRODUCTION_PROMOTION_RUNBOOK.md
+++ b/docs/runbooks/PRODUCTION_PROMOTION_RUNBOOK.md
@@ -1,8 +1,8 @@
 # Production Promotion Runbook
 
-<!-- LAST_VERIFIED: 044aa39 -->
+<!-- LAST_VERIFIED: caeed6a -->
 
-This runbook promotes a reviewed PipelineHealer release to the production Azure Container Apps lane for `pipelinehealer.canepro.me` and `api.pipelinehealer.canepro.me`.
+This runbook promotes a reviewed PipelineHealer release to an operator-owned production Azure Container Apps lane.
 
 Production is not a rename of the current dev deployment. It needs its own resource group, Container Apps, runtime configuration, secret injection, domain bindings, and smoke proof.
 
@@ -22,14 +22,14 @@ Recommended initial production lane:
 
 | Resource | Value |
 | --- | --- |
-| Resource group | `rg-canepro-ph-prod-eus2` |
+| Resource group | `<prod-resource-group>` |
 | Bicep parameters | `infra/main.prod.bicepparam` |
-| Container Apps environment | `cae-canepro-ph-prod-eus2` |
-| Backend app | `ca-canepro-ph-prod-backend` |
-| Frontend app | `ca-canepro-ph-prod-frontend` |
-| ACR | `caneprophacrprod01` |
-| Backend domain | `api.pipelinehealer.canepro.me` |
-| Frontend domain | `pipelinehealer.canepro.me` |
+| Container Apps environment | `<prod-container-apps-environment>` |
+| Backend app | `<prod-backend-app>` |
+| Frontend app | `<prod-frontend-app>` |
+| ACR | `<prod-acr-name>` |
+| Backend domain | `<api-domain>` |
+| Frontend domain | `<frontend-domain>` |
 | Secret source | Infisical `prod` environment |
 
 The first prod lane uses a separate production ACR. The release workflow still publishes public images to GHCR, so production promotion imports the reviewed GHCR release images into the prod ACR before running `deploy:release`.
@@ -40,8 +40,8 @@ Existing production history is in the current Cosmos DB lane:
 
 | Resource | Value |
 | --- | --- |
-| Resource group | `rg-canepro-ph-dev-eus` |
-| Cosmos account | `pipelinehealerdev-cosmos-zarrajklt3i5u` |
+| Resource group | `<existing-cosmos-resource-group>` |
+| Cosmos account | `<existing-cosmos-account>` |
 | Database | `pipelinehealer` |
 | Containers | `activities`, `workflow_runs` |
 | Partition key | `/repositoryId` |
@@ -59,20 +59,20 @@ After the production backend app exists, grant its identity access to the existi
 
 ```bash
 PROD_BACKEND_PRINCIPAL_ID="$(az containerapp show \
-  --resource-group rg-canepro-ph-prod-eus2 \
-  --name ca-canepro-ph-prod-backend \
+  --resource-group <prod-resource-group> \
+  --name <prod-backend-app> \
   --query identity.principalId \
   --output tsv)"
 
 COSMOS_CONTRIBUTOR_ROLE_ID="$(az cosmosdb sql role definition list \
-  --resource-group rg-canepro-ph-dev-eus \
-  --account-name pipelinehealerdev-cosmos-zarrajklt3i5u \
+  --resource-group <existing-cosmos-resource-group> \
+  --account-name <existing-cosmos-account> \
   --query "[?roleName=='Cosmos DB Built-in Data Contributor'].id | [0]" \
   --output tsv)"
 
 az cosmosdb sql role assignment create \
-  --resource-group rg-canepro-ph-dev-eus \
-  --account-name pipelinehealerdev-cosmos-zarrajklt3i5u \
+  --resource-group <existing-cosmos-resource-group> \
+  --account-name <existing-cosmos-account> \
   --role-definition-id "$COSMOS_CONTRIBUTOR_ROLE_ID" \
   --scope "/" \
   --principal-id "$PROD_BACKEND_PRINCIPAL_ID"
@@ -82,7 +82,7 @@ Set these values in the production Infisical environment before `deploy:release`
 
 ```env
 STORAGE_MODE=cosmos
-COSMOS_DB_ENDPOINT=https://pipelinehealerdev-cosmos-zarrajklt3i5u.documents.azure.com:443/
+COSMOS_DB_ENDPOINT=https://<existing-cosmos-account>.documents.azure.com:443/
 COSMOS_DB_DATABASE=pipelinehealer
 ```
 
@@ -92,12 +92,12 @@ Before pointing Cloudflare DNS at the new frontend/backend, verify the backend i
 
 ```bash
 az containerapp show \
-  --resource-group rg-canepro-ph-prod-eus2 \
-  --name ca-canepro-ph-prod-backend \
+  --resource-group <prod-resource-group> \
+  --name <prod-backend-app> \
   --query "properties.template.containers[0].env[?name=='COSMOS_DB_ENDPOINT' || name=='COSMOS_DB_DATABASE' || name=='STORAGE_MODE']"
 ```
 
-Do not delete, reinitialize, or rename the existing Cosmos account during this release. If a later release migrates data into `rg-canepro-ph-prod-eus2`, use a separate migration PR/runbook and capture pre/post counts for both containers.
+Do not delete, reinitialize, or rename the existing Cosmos account during this release. If a later release migrates data into the production resource group, use a separate migration PR/runbook and capture pre/post counts for both containers.
 
 ## Model Runtime
 
@@ -186,39 +186,39 @@ bash scripts/release_verify.sh v0.8.5
 Create the resource group if it does not exist:
 
 ```bash
-az group create --name rg-canepro-ph-prod-eus2 --location eastus2
+az group create --name <prod-resource-group> --location <azure-region>
 ```
 
 Preview the Azure changes first:
 
 ```bash
 az deployment group what-if \
-  --resource-group rg-canepro-ph-prod-eus2 \
+  --resource-group <prod-resource-group> \
   --template-file infra/acr.bicep \
-  --parameters acrName=caneprophacrprod01
+  --parameters acrName=<prod-acr-name>
 ```
 
 Create or update the production ACR:
 
 ```bash
 az deployment group create \
-  --resource-group rg-canepro-ph-prod-eus2 \
+  --resource-group <prod-resource-group> \
   --template-file infra/acr.bicep \
-  --parameters acrName=caneprophacrprod01
+  --parameters acrName=<prod-acr-name>
 ```
 
 Import the reviewed release images from public GHCR into the prod ACR:
 
 ```bash
 az acr import \
-  --name caneprophacrprod01 \
-  --source ghcr.io/canepro/pipelinehealer-backend:v0.8.5 \
+  --name <prod-acr-name> \
+  --source ghcr.io/<owner>/pipelinehealer-backend:v0.8.5 \
   --image pipelinehealer-backend:v0.8.5 \
   --force
 
 az acr import \
-  --name caneprophacrprod01 \
-  --source ghcr.io/canepro/pipelinehealer-frontend:v0.8.5 \
+  --name <prod-acr-name> \
+  --source ghcr.io/<owner>/pipelinehealer-frontend:v0.8.5 \
   --image pipelinehealer-frontend:v0.8.5 \
   --force
 ```
@@ -231,7 +231,7 @@ infisical run --env prod --path /pipelinehealer/prod --projectId <infisical-proj
 
 infisical run --env prod --path /pipelinehealer/prod --projectId <infisical-project-id> -- \
   az deployment group what-if \
-    --resource-group rg-canepro-ph-prod-eus2 \
+    --resource-group <prod-resource-group> \
     --template-file infra/main.bicep \
     --parameters infra/main.prod.bicepparam
 ```
@@ -244,7 +244,7 @@ infisical run --env prod --path /pipelinehealer/prod --projectId <infisical-proj
 
 infisical run --env prod --path /pipelinehealer/prod --projectId <infisical-project-id> -- \
   az deployment group create \
-    --resource-group rg-canepro-ph-prod-eus2 \
+    --resource-group <prod-resource-group> \
     --template-file infra/main.bicep \
     --parameters infra/main.prod.bicepparam
 ```
@@ -265,14 +265,14 @@ infisical run --env prod --path /pipelinehealer/prod --projectId <infisical-proj
   for key in API_AUTH_KEY ADMIN_API_KEY GITHUB_WEBHOOK_SECRET GITHUB_PERSONAL_ACCESS_TOKEN CODEX_APP_SERVER_WS_BEARER_TOKEN; do
     if [ -n "${!key:-}" ]; then printf "%s=%s\n" "$key" "${!key}" >>"$release_env"; fi
   done
-  PH_RG=rg-canepro-ph-prod-eus2 \
-  PH_BACKEND_APP=ca-canepro-ph-prod-backend \
-  PH_FRONTEND_APP=ca-canepro-ph-prod-frontend \
+  PH_RG=<prod-resource-group> \
+  PH_BACKEND_APP=<prod-backend-app> \
+  PH_FRONTEND_APP=<prod-frontend-app> \
   bash scripts/ph.sh deploy:release \
-    --resource-group rg-canepro-ph-prod-eus2 \
-    --acr-name caneprophacrprod01 \
-    --backend-app ca-canepro-ph-prod-backend \
-    --frontend-app ca-canepro-ph-prod-frontend \
+    --resource-group <prod-resource-group> \
+    --acr-name <prod-acr-name> \
+    --backend-app <prod-backend-app> \
+    --frontend-app <prod-frontend-app> \
     --release-version v0.8.5 \
     --env-file "$release_env" \
     --secure-secrets
@@ -286,9 +286,9 @@ After Container Apps have stable FQDNs, bind Cloudflare-backed custom domains th
 Minimum smoke proof:
 
 ```bash
-curl -fsS https://api.pipelinehealer.canepro.me/health
-curl -fsS https://pipelinehealer.canepro.me/runtime-config.js
-PH_RG=rg-canepro-ph-prod-eus2 PH_BACKEND_APP=ca-canepro-ph-prod-backend PH_FRONTEND_APP=ca-canepro-ph-prod-frontend bash scripts/ph.sh status
+curl -fsS https://<api-domain>/health
+curl -fsS https://<frontend-domain>/runtime-config.js
+PH_RG=<prod-resource-group> PH_BACKEND_APP=<prod-backend-app> PH_FRONTEND_APP=<prod-frontend-app> bash scripts/ph.sh status
 ```
 
 Expected:
@@ -314,14 +314,14 @@ infisical run --env prod --path /pipelinehealer/prod --projectId <infisical-proj
   for key in API_AUTH_KEY ADMIN_API_KEY GITHUB_WEBHOOK_SECRET GITHUB_PERSONAL_ACCESS_TOKEN; do
     if [ -n "${!key:-}" ]; then printf "%s=%s\n" "$key" "${!key}" >>"$release_env"; fi
   done
-  PH_RG=rg-canepro-ph-prod-eus2 \
-  PH_BACKEND_APP=ca-canepro-ph-prod-backend \
-  PH_FRONTEND_APP=ca-canepro-ph-prod-frontend \
+  PH_RG=<prod-resource-group> \
+  PH_BACKEND_APP=<prod-backend-app> \
+  PH_FRONTEND_APP=<prod-frontend-app> \
   bash scripts/ph.sh deploy:release \
-    --resource-group rg-canepro-ph-prod-eus2 \
-    --acr-name caneprophacrprod01 \
-    --backend-app ca-canepro-ph-prod-backend \
-    --frontend-app ca-canepro-ph-prod-frontend \
+    --resource-group <prod-resource-group> \
+    --acr-name <prod-acr-name> \
+    --backend-app <prod-backend-app> \
+    --frontend-app <prod-frontend-app> \
     --release-version v0.7.2 \
     --env-file "$release_env" \
     --secure-secrets

--- a/docs/runbooks/RELEASE_RUNBOOK.md
+++ b/docs/runbooks/RELEASE_RUNBOOK.md
@@ -1,6 +1,6 @@
 # Release Runbook
 
-<!-- LAST_VERIFIED: 50ba6f3 -->
+<!-- LAST_VERIFIED: caeed6a -->
 
 End-to-end release procedure for PipelineHealer using the repo release helpers.
 
@@ -45,7 +45,7 @@ GitHub requirements:
 
 Optional repository variable:
 
-- `ACR_NAME` (defaults to `caneprophacr01`)
+- `ACR_NAME` (target Azure Container Registry for optional ACR mirroring; no public default)
 
 ## Azure Prerequisites (Optional, ACR Mirror + Azure Promotion)
 

--- a/scripts/demo/run_e2e_azure.sh
+++ b/scripts/demo/run_e2e_azure.sh
@@ -17,9 +17,9 @@ Usage:
   scripts/demo/run_e2e_azure.sh [options]
 
 Options:
-  --repo <owner/repo>         Demo repo (default: Canepro/pipelinehealer-demo)
-  --resource-group <name>     Azure resource group (default: rg-canepro-ph-dev-eus)
-  --backend-app <name>        Azure backend Container App (default: ca-canepro-ph-backend)
+  --repo <owner/repo>         Demo repo (or DEMO_REPO)
+  --resource-group <name>     Azure resource group (or PH_RG)
+  --backend-app <name>        Azure backend Container App (or PH_BACKEND_APP)
   --demo-repo-dir <path>      Local checkout of demo repo (default: ./demo-repo)
   --wait-seconds <n>          Max seconds to wait for activity terminal status (default: 180)
   --ci-signal-wait-seconds <n> Extra seconds to wait for CI doctor signal (default: 180)
@@ -36,9 +36,9 @@ EOF
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-DEMO_REPO="Canepro/pipelinehealer-demo"
-AZ_RESOURCE_GROUP="rg-canepro-ph-dev-eus"
-BACKEND_APP="ca-canepro-ph-backend"
+DEMO_REPO="${DEMO_REPO:-}"
+AZ_RESOURCE_GROUP="${PH_RG:-}"
+BACKEND_APP="${PH_BACKEND_APP:-}"
 DEMO_REPO_DIR="$REPO_ROOT/demo-repo"
 WAIT_SECONDS="180"
 CI_SIGNAL_WAIT_SECONDS="180"
@@ -112,6 +112,17 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+missing_config=()
+[[ -n "${DEMO_REPO:-}" ]] || missing_config+=("--repo or DEMO_REPO")
+[[ -n "${AZ_RESOURCE_GROUP:-}" ]] || missing_config+=("--resource-group or PH_RG")
+[[ -n "${BACKEND_APP:-}" ]] || missing_config+=("--backend-app or PH_BACKEND_APP")
+if [[ "${#missing_config[@]}" -gt 0 ]]; then
+  echo "Missing Azure demo target configuration:" >&2
+  printf '  %s\n' "${missing_config[@]}" >&2
+  echo "Provide these with flags or environment variables; the public CLI has no built-in production defaults." >&2
+  exit 2
+fi
 
 for cmd in gh az curl; do
   if ! command -v "$cmd" >/dev/null 2>&1; then

--- a/scripts/deploy/redeploy_azure_containerapps.sh
+++ b/scripts/deploy/redeploy_azure_containerapps.sh
@@ -19,10 +19,10 @@ Usage:
   scripts/deploy/redeploy_azure_containerapps.sh [options]
 
 Options:
-  --resource-group <name>   Azure resource group (default: rg-canepro-ph-dev-eus)
-  --acr-name <name>         Azure Container Registry name (default: caneprophacr01)
-  --backend-app <name>      Backend Container App (default: ca-canepro-ph-backend)
-  --frontend-app <name>     Frontend Container App (default: ca-canepro-ph-frontend)
+  --resource-group <name>   Azure resource group (or PH_RG)
+  --acr-name <name>         Azure Container Registry name (or PH_ACR_NAME / ACR_NAME)
+  --backend-app <name>      Backend Container App (or PH_BACKEND_APP)
+  --frontend-app <name>     Frontend Container App (or PH_FRONTEND_APP)
   --engine <podman|docker>  Force container engine (default: auto-detect)
   --remote-build            Build images with ACR Tasks instead of local Docker/Podman
   --env-file <path>         Backend env file (default: <repo>/backend/.env)
@@ -44,11 +44,12 @@ EOF
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-AZ_RESOURCE_GROUP="rg-canepro-ph-dev-eus"
-ACR_NAME="caneprophacr01"
-BACKEND_APP="ca-canepro-ph-backend"
-FRONTEND_APP="ca-canepro-ph-frontend"
-ENV_FILE="$REPO_ROOT/backend/.env"
+AZ_RESOURCE_GROUP="${PH_RG:-}"
+ACR_NAME_ENV="${ACR_NAME:-}"
+ACR_NAME="${PH_ACR_NAME:-$ACR_NAME_ENV}"
+BACKEND_APP="${PH_BACKEND_APP:-}"
+FRONTEND_APP="${PH_FRONTEND_APP:-}"
+ENV_FILE="${PH_ENV_FILE:-$REPO_ROOT/backend/.env}"
 IMAGE_TAG="$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || date +%Y%m%d%H%M%S)"
 CONTAINER_ENGINE="auto"
 COMPOSE_ENV_FILE=""
@@ -297,6 +298,20 @@ done
 
 if [[ "$ENV_FILE" != /* ]]; then
   ENV_FILE="$REPO_ROOT/$ENV_FILE"
+fi
+
+missing_config=()
+[[ -n "${AZ_RESOURCE_GROUP:-}" ]] || missing_config+=("--resource-group or PH_RG")
+[[ -n "${BACKEND_APP:-}" ]] || missing_config+=("--backend-app or PH_BACKEND_APP")
+[[ -n "${FRONTEND_APP:-}" ]] || missing_config+=("--frontend-app or PH_FRONTEND_APP")
+if [[ "$MODE" == "full" || "$MODE" == "release" ]]; then
+  [[ -n "${ACR_NAME:-}" ]] || missing_config+=("--acr-name or PH_ACR_NAME/ACR_NAME")
+fi
+if [[ "${#missing_config[@]}" -gt 0 ]]; then
+  echo "Missing Azure deployment target configuration:" >&2
+  printf '  %s\n' "${missing_config[@]}" >&2
+  echo "Provide these with flags or environment variables; the public CLI has no built-in production defaults." >&2
+  exit 2
 fi
 
 for cmd in az curl tr grep cut sed; do

--- a/scripts/infisical_runtime_migration.py
+++ b/scripts/infisical_runtime_migration.py
@@ -91,7 +91,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--env-file", default="backend/.env")
     parser.add_argument("--env", default=os.getenv("INFISICAL_ENVIRONMENT", "dev"))
-    parser.add_argument("--path", default=os.getenv("INFISICAL_SECRET_PATH", "/personal/pipelinehealer"))
+    parser.add_argument("--path", default=os.getenv("INFISICAL_SECRET_PATH", "/pipelinehealer/dev"))
     parser.add_argument("--project-id", default=os.getenv("INFISICAL_PROJECT_ID", ""))
     parser.add_argument("--domain", default=os.getenv("INFISICAL_API_URL", ""))
     parser.add_argument("--token", default=os.getenv("INFISICAL_TOKEN", ""))

--- a/scripts/ph.sh
+++ b/scripts/ph.sh
@@ -13,16 +13,14 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-AZ_RESOURCE_GROUP="${PH_RG:-rg-canepro-ph-dev-eus}"
-BACKEND_APP="${PH_BACKEND_APP:-ca-canepro-ph-backend}"
-FRONTEND_APP="${PH_FRONTEND_APP:-ca-canepro-ph-frontend}"
+AZ_RESOURCE_GROUP="${PH_RG:-}"
+BACKEND_APP="${PH_BACKEND_APP:-}"
+FRONTEND_APP="${PH_FRONTEND_APP:-}"
 
 # Namespace background deploy state files by resource group to avoid collisions
 # between concurrent runs, different users, or multiple repos.
-_deploy_state_dir="/tmp/ph-deploy-${AZ_RESOURCE_GROUP}"
-mkdir -p "$_deploy_state_dir" 2>/dev/null || true
-DEPLOY_LOG="${PH_DEPLOY_LOG:-$_deploy_state_dir/redeploy.log}"
-DEPLOY_PID="${PH_DEPLOY_PID:-$_deploy_state_dir/redeploy.pid}"
+DEPLOY_LOG="${PH_DEPLOY_LOG:-}"
+DEPLOY_PID="${PH_DEPLOY_PID:-}"
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -36,6 +34,7 @@ Usage:
   bash scripts/ph.sh <command> [options]
 
 Commands:
+  init              Bootstrap local/dev env and print the UI-first setup path
   deploy            Full Azure redeploy (build/push/update/verify)
   deploy:release    Azure redeploy from existing ACR release images (no local build)
   deploy:env        Update runtime env vars only (backend + frontend, no image rebuild)
@@ -47,7 +46,7 @@ Commands:
   webhook:disable   Disable Azure webhook for one repo
   rollout:canary    Configure issue-only canary mode for selected repos and attach webhooks
   demo:e2e          Run scripted Azure E2E demo flow with CI-signal verification
-  demo:proof        Show latest CI runs, PRs, and issues for a repo (default demo repo)
+  demo:proof        Show latest CI runs, PRs, and issues for an explicit repo
   demo:reset        Reset demo fixture repo for dependency/lint failures
   warm              Set backend/frontend min-replicas to 1
   lowcost           Set backend/frontend min-replicas to 0
@@ -67,6 +66,8 @@ Commands:
   help              Show this help
 
 Examples:
+  bash scripts/ph.sh init
+  bash scripts/ph.sh init --auto-fix --repos owner/repo --llm-provider codex_app_server
   bash scripts/ph.sh deploy
   bash scripts/ph.sh deploy --secure-secrets
   bash scripts/ph.sh deploy:release --release-version vX.Y.Z
@@ -77,8 +78,8 @@ Examples:
   bash scripts/ph.sh urls
   bash scripts/ph.sh webhook:add --repo owner/repo
   bash scripts/ph.sh rollout:canary --repos owner/repo1,owner/repo2
-  bash scripts/ph.sh demo:e2e --skip-webhook-sync
-  bash scripts/ph.sh demo:e2e --triggers dependency,lint,test,build_config,timeout --wait-seconds 180 --ci-signal-wait-seconds 180 --strict
+  bash scripts/ph.sh demo:e2e --repo owner/repo --skip-webhook-sync
+  bash scripts/ph.sh demo:e2e --repo owner/repo --triggers dependency,lint,test,build_config,timeout --wait-seconds 180 --ci-signal-wait-seconds 180 --strict
   bash scripts/ph.sh demo:proof --repo owner/repo
   bash scripts/ph.sh settings:persist --from-settings
   bash scripts/ph.sh settings:persist:verify --from-settings
@@ -103,8 +104,8 @@ Local mode:
   Commands that work locally: settings:check, settings:audit, audit:proof,
   aoai:check, backfill, logs, logs:raw, logs:grep, demo:proof, demo:reset, help.
 
-  Azure-only commands (deploy, deploy:release, warm, lowcost, status, urls, webhook:*,
-  rollout:canary, demo:e2e) print a clear error when PH_BACKEND_URL is set.
+  Azure-only commands require PH_RG and app-name env vars or equivalent flags.
+  They also print a clear error when PH_BACKEND_URL is set.
 EOF
 }
 
@@ -128,7 +129,7 @@ require_arg() {
 
 env_file() {
   # Single source of truth for runtime settings used by helper commands.
-  echo "$REPO_ROOT/backend/.env"
+  echo "${PH_ENV_FILE:-$REPO_ROOT/backend/.env}"
 }
 
 read_env_key() {
@@ -169,6 +170,237 @@ upsert_env_key() {
   chmod 600 "$file"
 }
 
+random_secret() {
+  need_cmd python3
+  python3 - <<'PY'
+import secrets
+
+print(secrets.token_urlsafe(32))
+PY
+}
+
+cmd_init() {
+  local mode="local"
+  local llm_provider="codex_app_server"
+  local repos_csv=""
+  local auto_fix="0"
+  local force_env="0"
+  local skip_env="0"
+  local infisical_project_id="${INFISICAL_PROJECT_ID:-}"
+  local infisical_environment="${INFISICAL_ENVIRONMENT:-dev}"
+  local infisical_secret_path="${INFISICAL_SECRET_PATH:-/pipelinehealer/dev}"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --mode)
+        require_arg "$1" "${2-}"
+        mode="$2"
+        shift 2
+        ;;
+      --mode=*)
+        mode="${1#*=}"
+        shift
+        ;;
+      --llm-provider)
+        require_arg "$1" "${2-}"
+        llm_provider="$2"
+        shift 2
+        ;;
+      --llm-provider=*)
+        llm_provider="${1#*=}"
+        shift
+        ;;
+      --repos)
+        require_arg "$1" "${2-}"
+        repos_csv="$2"
+        shift 2
+        ;;
+      --repos=*)
+        repos_csv="${1#*=}"
+        shift
+        ;;
+      --auto-fix)
+        auto_fix="1"
+        shift
+        ;;
+      --force-env)
+        force_env="1"
+        shift
+        ;;
+      --skip-env)
+        skip_env="1"
+        shift
+        ;;
+      --infisical-project-id)
+        require_arg "$1" "${2-}"
+        infisical_project_id="$2"
+        shift 2
+        ;;
+      --infisical-project-id=*)
+        infisical_project_id="${1#*=}"
+        shift
+        ;;
+      --infisical-env)
+        require_arg "$1" "${2-}"
+        infisical_environment="$2"
+        shift 2
+        ;;
+      --infisical-env=*)
+        infisical_environment="${1#*=}"
+        shift
+        ;;
+      --infisical-path)
+        require_arg "$1" "${2-}"
+        infisical_secret_path="$2"
+        shift 2
+        ;;
+      --infisical-path=*)
+        infisical_secret_path="${1#*=}"
+        shift
+        ;;
+      --yes)
+        shift
+        ;;
+      *)
+        echo "Unknown argument for init: $1" >&2
+        exit 2
+        ;;
+    esac
+  done
+
+  case "${mode,,}" in
+    local|azure|prod|production) ;;
+    *)
+      echo "Invalid --mode '$mode' (expected local, azure, prod, or production)." >&2
+      exit 2
+      ;;
+  esac
+
+  case "${llm_provider,,}" in
+    azure_openai|openai_compatible|codex_app_server|custom) ;;
+    *)
+      echo "Invalid --llm-provider '$llm_provider'." >&2
+      exit 2
+      ;;
+  esac
+
+  local env_path env_created
+  env_path="$(env_file)"
+  env_created="0"
+
+  echo "PipelineHealer init"
+  echo "  mode: ${mode,,}"
+  echo "  env:  $env_path"
+  echo
+
+  local required_cmds=(bash python3 curl git)
+  local optional_cmds=(uv bun docker podman az gh infisical)
+  local cmd missing_required=0
+  echo "Dependency check:"
+  for cmd in "${required_cmds[@]}"; do
+    if command -v "$cmd" >/dev/null 2>&1; then
+      echo "  ok       $cmd"
+    else
+      echo "  missing  $cmd (required)"
+      missing_required=1
+    fi
+  done
+  for cmd in "${optional_cmds[@]}"; do
+    if command -v "$cmd" >/dev/null 2>&1; then
+      echo "  ok       $cmd"
+    else
+      echo "  optional $cmd"
+    fi
+  done
+  if [[ "$missing_required" == "1" ]]; then
+    echo "Install missing required commands and rerun init." >&2
+    exit 1
+  fi
+  echo
+
+  if [[ "$skip_env" == "1" ]]; then
+    echo "Env scaffold skipped (--skip-env)."
+  elif [[ -f "$env_path" && "$force_env" != "1" ]]; then
+    echo "Env file already exists. Leaving values unchanged."
+    echo "Use --force-env to recreate it from backend/.env.example."
+  else
+    mkdir -p "$(dirname "$env_path")"
+    cp "$REPO_ROOT/backend/.env.example" "$env_path"
+    chmod 600 "$env_path"
+    env_created="1"
+
+    upsert_env_key "API_AUTH_KEY" "$(random_secret)"
+    upsert_env_key "ADMIN_API_KEY" "$(random_secret)"
+    upsert_env_key "AUDIT_SALT" "$(random_secret)"
+    upsert_env_key "GITHUB_WEBHOOK_SECRET" "$(random_secret)"
+    upsert_env_key "SETTINGS_DB_ENCRYPTION_KEY" "$(random_secret)"
+    upsert_env_key "LLM_PROVIDER" "${llm_provider,,}"
+    upsert_env_key "CODEX_APP_SERVER_MODEL" "gpt-5.4"
+
+    if [[ "${mode,,}" == "local" ]]; then
+      upsert_env_key "ENVIRONMENT" "development"
+      upsert_env_key "STORAGE_MODE" "memory"
+      upsert_env_key "AUTH_MODE" "api_key"
+      upsert_env_key "VITE_AUTH_MODE" "none"
+    else
+      upsert_env_key "ENVIRONMENT" "production"
+      upsert_env_key "AUTH_MODE" "hybrid"
+      upsert_env_key "VITE_AUTH_MODE" "entra"
+    fi
+
+    if [[ -n "${repos_csv:-}" ]]; then
+      upsert_env_key "PH_ALLOWED_REPOS" "$(echo "$repos_csv" | tr -d '[:space:]')"
+    fi
+
+    if [[ "$auto_fix" == "1" ]]; then
+      upsert_env_key "AUTO_APPLY_REMEDIATION" "true"
+      upsert_env_key "AUTO_CREATE_PR" "true"
+      upsert_env_key "AUTO_CREATE_ISSUE" "true"
+      upsert_env_key "AUTO_RETRY_WORKFLOW" "false"
+      upsert_env_key "AUTO_MERGE_REMEDIATION_PRS" "true"
+      upsert_env_key "AUTO_MERGE_STRATEGY" "merge_when_clean"
+      upsert_env_key "AUTO_MERGE_REQUIRE_CLEAN_CHECKS" "true"
+    fi
+
+    if [[ -n "${infisical_project_id:-}" ]]; then
+      upsert_env_key "SETTINGS_SECRET_BACKEND" "infisical"
+      upsert_env_key "INFISICAL_PROJECT_ID" "$infisical_project_id"
+      upsert_env_key "INFISICAL_ENVIRONMENT" "$infisical_environment"
+      upsert_env_key "INFISICAL_SECRET_PATH" "$infisical_secret_path"
+    fi
+
+    echo "Created env scaffold with generated local secrets. Values were not printed."
+  fi
+
+  echo
+  echo "Next commands:"
+  echo "  backend:  cd backend && uv pip install -e '.[dev]' && uvicorn src.main:app --reload"
+  echo "  frontend: cd frontend && bun install && bun run dev"
+  if [[ -n "${infisical_project_id:-}" ]]; then
+    echo "  deploy:   infisical run --env $infisical_environment --path $infisical_secret_path --projectId <project-id> -- bash scripts/ph.sh deploy --secure-secrets"
+  else
+    echo "  deploy:   bash scripts/ph.sh deploy --secure-secrets"
+  fi
+  echo
+  echo "Finish setup in the UI:"
+  echo "  local dev:      http://127.0.0.1:5173/app/settings"
+  echo "  local container: http://127.0.0.1:3000/app/settings"
+  if [[ -n "${PH_FRONTEND_URL:-}" ]]; then
+    echo "  deployed:       ${PH_FRONTEND_URL%/}/app/settings"
+  else
+    echo "  deployed:       set PH_FRONTEND_URL to print your deployed Settings URL"
+  fi
+  echo
+  echo "UI-first fields already supported: model provider, Codex App Server, GitHub token presence, repo allowlist, auto-fix policy, MCP policy, handoff targets, and write-only secrets."
+  if [[ "$auto_fix" == "1" && -z "${repos_csv:-}" ]]; then
+    echo
+    echo "Warning: --auto-fix was enabled without --repos. Set PH_ALLOWED_REPOS before wiring production webhooks."
+  fi
+  if [[ "$env_created" == "1" ]]; then
+    echo "Env scaffold complete."
+  fi
+}
+
 # ---------------------------------------------------------------------------
 # Local vs Azure mode
 # ---------------------------------------------------------------------------
@@ -195,6 +427,72 @@ require_azure() {
   fi
 }
 
+require_azure_app_config() {
+  local command_name="$1"
+  local -a missing=()
+  [[ -n "${AZ_RESOURCE_GROUP:-}" ]] || missing+=("PH_RG")
+  [[ -n "${BACKEND_APP:-}" ]] || missing+=("PH_BACKEND_APP")
+  [[ -n "${FRONTEND_APP:-}" ]] || missing+=("PH_FRONTEND_APP")
+  if [[ "${#missing[@]}" -gt 0 ]]; then
+    echo "Error: '$command_name' needs Azure Container Apps target env vars: ${missing[*]}." >&2
+    echo "Example:" >&2
+    echo "  PH_RG=<resource-group> PH_BACKEND_APP=<backend-app> PH_FRONTEND_APP=<frontend-app> bash scripts/ph.sh $command_name" >&2
+    exit 2
+  fi
+}
+
+require_backend_app_config() {
+  local command_name="$1"
+  local -a missing=()
+  [[ -n "${AZ_RESOURCE_GROUP:-}" ]] || missing+=("PH_RG")
+  [[ -n "${BACKEND_APP:-}" ]] || missing+=("PH_BACKEND_APP")
+  if [[ "${#missing[@]}" -gt 0 ]]; then
+    echo "Error: '$command_name' needs Azure backend target env vars: ${missing[*]}." >&2
+    echo "Example:" >&2
+    echo "  PH_RG=<resource-group> PH_BACKEND_APP=<backend-app> bash scripts/ph.sh $command_name" >&2
+    exit 2
+  fi
+}
+
+resource_group_from_args() {
+  local rg="${AZ_RESOURCE_GROUP:-}"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --resource-group)
+        if [[ -n "${2-}" && "${2-}" != --* ]]; then
+          rg="$2"
+          shift 2
+        else
+          break
+        fi
+        ;;
+      --resource-group=*)
+        rg="${1#*=}"
+        shift
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+  printf '%s\n' "$rg"
+}
+
+prepare_deploy_state_paths() {
+  local command_name="$1"
+  shift
+  local rg
+  rg="$(resource_group_from_args "$@")"
+  if [[ -z "${rg:-}" ]]; then
+    echo "Error: '$command_name' needs --resource-group or PH_RG for deploy state files." >&2
+    exit 2
+  fi
+  local deploy_state_dir="/tmp/ph-deploy-${rg}"
+  mkdir -p "$deploy_state_dir"
+  DEPLOY_LOG="${PH_DEPLOY_LOG:-$deploy_state_dir/redeploy.log}"
+  DEPLOY_PID="${PH_DEPLOY_PID:-$deploy_state_dir/redeploy.pid}"
+}
+
 resolve_backend_url() {
   if is_local_mode; then
     # Strip trailing slash for consistency
@@ -207,6 +505,7 @@ resolve_backend_url() {
     echo "$local_url"
   else
     need_cmd az
+    require_backend_app_config "resolve-backend-url"
     local fqdn
     fqdn="$(az containerapp show \
       -g "$AZ_RESOURCE_GROUP" \
@@ -227,6 +526,7 @@ resolve_backend_fqdn() {
     exit 1
   fi
   need_cmd az
+  require_backend_app_config "resolve-backend-fqdn"
   local fqdn
   fqdn="$(az containerapp show \
     -g "$AZ_RESOURCE_GROUP" \
@@ -243,6 +543,7 @@ resolve_backend_fqdn() {
 resolve_frontend_fqdn() {
   require_azure "urls"
   need_cmd az
+  require_azure_app_config "urls"
   local fqdn
   fqdn="$(az containerapp show \
     -g "$AZ_RESOURCE_GROUP" \
@@ -283,12 +584,13 @@ sync_repo_webhook() {
   local repo="$1"
   local mode="$2"  # add|disable
   need_cmd gh
-  need_cmd az
 
   if [[ -z "${repo:-}" || "$repo" != */* ]]; then
     echo "Invalid repo value: '$repo' (expected owner/name)" >&2
     exit 2
   fi
+  require_backend_app_config "webhook:$mode"
+  need_cmd az
 
   local backend_fqdn backend_url webhook_secret
   backend_fqdn="$(resolve_backend_fqdn)"
@@ -460,6 +762,12 @@ cmd_rollout_canary() {
     exit 2
   fi
 
+  if [[ "$apply_env" == "1" ]]; then
+    require_azure_app_config "rollout:canary"
+  else
+    require_backend_app_config "rollout:canary"
+  fi
+
   # Canary defaults: constrain scope and keep remediation conservative.
   # Keep explicit toggles so behavior stays stable even when policy gates evolve.
   upsert_env_key "PH_ALLOWED_REPOS" "$normalized_csv"
@@ -502,6 +810,7 @@ cmd_rollout_canary() {
 
 scale_mode() {
   local min="$1"
+  require_azure_app_config "scale"
   need_cmd az
   az containerapp update -g "$AZ_RESOURCE_GROUP" -n "$BACKEND_APP" --min-replicas "$min" >/dev/null
   az containerapp update -g "$AZ_RESOURCE_GROUP" -n "$FRONTEND_APP" --min-replicas "$min" >/dev/null
@@ -637,7 +946,7 @@ audit_proof() {
 
 cmd_demo_proof() {
   need_cmd gh
-  local repo="${DEMO_REPO:-Canepro/pipelinehealer-demo}"
+  local repo="${DEMO_REPO:-}"
   local limit="10"
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -646,8 +955,8 @@ cmd_demo_proof() {
           repo="$2"
           shift 2
         else
-          echo "Warning: --repo was provided without a value or was followed by another flag; falling back to $repo" >&2
-          shift 1
+          echo "Error: --repo requires a value." >&2
+          exit 2
         fi
         ;;
       --limit)
@@ -665,6 +974,11 @@ cmd_demo_proof() {
         ;;
     esac
   done
+  if [[ -z "${repo:-}" ]]; then
+    echo "Usage: bash scripts/ph.sh demo:proof --repo owner/repo" >&2
+    echo "Set DEMO_REPO=owner/repo if you want a shell default." >&2
+    exit 2
+  fi
   echo "Recent CI runs:"
   gh run list -R "$repo" --workflow CI --limit "$limit"
   echo
@@ -681,6 +995,7 @@ cmd_demo_proof() {
 
 show_urls() {
   require_azure "urls"
+  require_azure_app_config "urls"
   local backend_fqdn frontend_fqdn
   backend_fqdn="$(resolve_backend_fqdn)"
   frontend_fqdn="$(resolve_frontend_fqdn)"
@@ -690,6 +1005,7 @@ show_urls() {
 
 show_status() {
   require_azure "status"
+  require_azure_app_config "status"
   need_cmd az
   az containerapp list \
     -g "$AZ_RESOURCE_GROUP" \
@@ -703,6 +1019,7 @@ show_status() {
 
 deploy_bg() {
   need_cmd nohup
+  prepare_deploy_state_paths "deploy:bg" "$@"
   nohup bash "$SCRIPT_DIR/deploy/redeploy_azure_containerapps.sh" "$@" >"$DEPLOY_LOG" 2>&1 &
   local pid="$!"
   echo "$pid" > "$DEPLOY_PID"
@@ -720,6 +1037,7 @@ deploy_bg() {
 }
 
 deploy_status() {
+  prepare_deploy_state_paths "deploy:status" "$@"
   if [[ ! -f "$DEPLOY_PID" ]]; then
     echo "No deploy pid file found: $DEPLOY_PID"
     return 0
@@ -777,6 +1095,7 @@ cmd_logs() {
       | grep -v "x-ms-" \
       || true
   else
+    require_backend_app_config "logs"
     need_cmd az
     az containerapp logs show \
       -n "$BACKEND_APP" \
@@ -823,6 +1142,7 @@ cmd_logs_raw() {
     fi
     $compose_cmd --env-file "$REPO_ROOT/backend/.env" logs --tail "$tail_count" backend 2>/dev/null || true
   else
+    require_backend_app_config "logs:raw"
     need_cmd az
     az containerapp logs show \
       -n "$BACKEND_APP" \
@@ -867,6 +1187,7 @@ cmd_logs_grep() {
       | grep -iE "$pattern" \
       || true
   else
+    require_backend_app_config "logs:grep"
     need_cmd az
     az containerapp logs show \
       -n "$BACKEND_APP" \
@@ -2175,6 +2496,9 @@ case "$COMMAND" in
   help|-h|--help)
     usage
     ;;
+  init)
+    cmd_init "$@"
+    ;;
   deploy)
     require_azure "deploy"
     bash "$SCRIPT_DIR/deploy/redeploy_azure_containerapps.sh" "$@"
@@ -2206,6 +2530,7 @@ case "$COMMAND" in
     ;;
   deploy:logs)
     require_azure "deploy:logs"
+    prepare_deploy_state_paths "deploy:logs" "$@"
     if [[ ! -f "$DEPLOY_LOG" ]]; then
       echo "No log file yet: $DEPLOY_LOG"
       exit 0
@@ -2214,7 +2539,7 @@ case "$COMMAND" in
     ;;
   deploy:status)
     require_azure "deploy:status"
-    deploy_status
+    deploy_status "$@"
     ;;
   urls)
     show_urls


### PR DESCRIPTION
## Summary
- add `bash scripts/ph.sh init` to create a local env scaffold, generate bootstrap secrets without printing values, default new installs to Codex App Server `gpt-5.4`, and point setup into `/app/settings`
- remove maintainer Azure/demo defaults from active CLI paths so ACA resource names, ACR, domains, and demo repos must come from operator flags or env
- update Infisical examples to use `/pipelinehealer/dev`, keep docs placeholder-based, and add regression tests for public-safe CLI behavior

## Verification
- `bash -n scripts/ph.sh scripts/deploy/redeploy_azure_containerapps.sh scripts/demo/run_e2e_azure.sh`
- `shellcheck scripts/ph.sh scripts/deploy/redeploy_azure_containerapps.sh scripts/demo/run_e2e_azure.sh scripts/demo/reset_demo_fixtures.sh scripts/release.sh scripts/check_version_sync.sh`
- `cd backend && ../.venv/bin/ruff check tests/test_ph_init.py tests/test_redeploy_azure_env_sync.py`
- `cd backend && ../.venv/bin/pytest -q tests/test_ph_init.py tests/test_redeploy_azure_env_sync.py`
- `git diff --check`
- redacted init smoke: generated `backend.env` mode `600`, output did not include generated secret assignments or maintainer prod identifiers

## Notes
- No secret values were read, printed, committed, or moved.
- Public repo docs now use operator-owned placeholders for Azure production promotion.