### PR TITLE
fix: require stdio for local Codex handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-<!-- LAST_VERIFIED: 17e4893 -->
+<!-- LAST_VERIFIED: b619406 -->
 
 All notable changes to this project will be documented in this file.
 
@@ -40,10 +40,10 @@ The format is based on Keep a Changelog and this repo uses Semantic Versioning.
   receiver. The agent handoff config API now reports `local_codex_enabled`.
 - The backend container image now includes `git`, required for local handoff
   workspace clones. The `codex` CLI is not bundled; local execution also
-  requires it on the backend host (or a loopback Codex App Server).
-- Local execution refuses to run against a non-loopback WebSocket Codex App
-  Server, since the remote runtime cannot see the backend's workspace
-  filesystem.
+  requires it on the backend host with stdio transport.
+- Local execution refuses WebSocket Codex App Server transport for handoff
+  turns because the backend cannot sanitize an already-running WebSocket server
+  environment before handing it an untrusted workspace (`b619406`).
 - Workspace-write Codex turns run with a sanitized subprocess environment and
   token-free clone URLs: backend and provider secrets (GitHub tokens, Azure
   keys, `OPENAI_API_KEY`, Infisical tokens, admin keys) are not readable by
@@ -55,6 +55,8 @@ The format is based on Keep a Changelog and this repo uses Semantic Versioning.
 - Addressed PR review findings for remote handoff precedence, failing-branch
   selection, fork-PR retarget visibility, enabled-target gating, and refreshed
   doc verification markers (`7986ebc`, `9ce45df`, `bea51f1`).
+- Merged the local Codex handoff PR and backfilled its release-scope changelog
+  references (`83b9789`, `765ccb0`).
 - Recorded post-v0.8.10 merged work already on `main`: codex runtime roadmap
   and log-compaction docs (`4019f4b`, `f4755fa`), artifact lifecycle hygiene
   (`c5d6835`, `87f0798`, `357ad13`, `32641b6`, `d3b3d1a`, `2d6891b`), legacy

--- a/backend/src/agents/local_handoff.py
+++ b/backend/src/agents/local_handoff.py
@@ -22,11 +22,10 @@ from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
 from uuid import uuid4
 
 from ..config import get_settings
-from ..llm.codex_app_server import CodexAppServerAgent, is_loopback_websocket_host
+from ..llm.codex_app_server import CodexAppServerAgent
 from ..models import (
     HANDOFF_EVENT_STATUS,
     ActivityRecord,
@@ -247,19 +246,16 @@ class _ChangeSet:
 
 
 def _check_transport_supports_local_workspace(settings: Any) -> None:
-    """Reject transports where the app-server cannot see this host's filesystem."""
+    """Reject transports this process cannot confine for untrusted workspaces."""
     transport = str(
         getattr(settings, "codex_app_server_transport", "stdio") or "stdio"
     ).strip().lower()
     if transport != "websocket":
         return
-    ws_url = str(getattr(settings, "codex_app_server_ws_url", "") or "").strip()
-    host = urlparse(ws_url).hostname or ""
-    if not is_loopback_websocket_host(host):
-        raise RuntimeError(
-            "Local Codex handoff execution requires a Codex App Server that shares "
-            "this host's filesystem; use stdio transport or a loopback WebSocket URL"
-        )
+    raise RuntimeError(
+        "Local Codex handoff execution requires stdio transport so the "
+        "workspace-write Codex process can run with a sanitized environment"
+    )
 
 
 async def _execute(

--- a/backend/tests/test_agent_handoff.py
+++ b/backend/tests/test_agent_handoff.py
@@ -1124,7 +1124,7 @@ async def test_local_codex_collect_changes_skips_symlinked_files(
 
 
 @pytest.mark.asyncio
-async def test_local_codex_executor_rejects_remote_websocket_transport(
+async def test_local_codex_executor_rejects_websocket_transport(
     monkeypatch: pytest.MonkeyPatch,
     _storage: InMemoryStorage,
 ) -> None:
@@ -1136,8 +1136,7 @@ async def test_local_codex_executor_rejects_remote_websocket_transport(
     )
 
     monkeypatch.setenv("CODEX_APP_SERVER_TRANSPORT", "websocket")
-    monkeypatch.setenv("CODEX_APP_SERVER_WS_URL", "wss://codex.internal.example/api")
-    monkeypatch.setenv("CODEX_APP_SERVER_WS_ALLOW_REMOTE", "true")
+    monkeypatch.setenv("CODEX_APP_SERVER_WS_URL", "ws://127.0.0.1:8787/api")
     _local_codex_env(monkeypatch)
 
     activity_id = await _make_activity(_storage, 408)
@@ -1163,7 +1162,8 @@ async def test_local_codex_executor_rejects_remote_websocket_transport(
     assert stored is not None
     assert stored.status == HandoffSessionStatus.FAILED
     messages = await _storage.list_handoff_messages(session.id)
-    assert "shares this host's filesystem" in messages[-1].body
+    assert "requires stdio transport" in messages[-1].body
+    assert "sanitized environment" in messages[-1].body
 
 
 @pytest.mark.asyncio

--- a/docs/architecture/LLM_AND_AGENT_RUNTIME.md
+++ b/docs/architecture/LLM_AND_AGENT_RUNTIME.md
@@ -1,6 +1,6 @@
 # LLM and Agent Runtime
 
-<!-- LAST_VERIFIED: 42e442f -->
+<!-- LAST_VERIFIED: b619406 -->
 
 This document is the operator-facing contract for how PipelineHealer uses LLMs and agents at runtime.
 
@@ -88,6 +88,7 @@ Precedence and scope:
 - A configured `CODEX_APP_SERVER_HANDOFF_URL` (or legacy `AGENT_HANDOFF_WEBHOOK_URL`) always wins; local execution only serves sessions with no remote receiver.
 - Local execution requires `git` and the `codex` CLI on the backend host, plus a GitHub token with contents and pull-request write access for publishing.
 - The agent turn runs with `sandboxPolicy=workspaceWrite` and no network access; only the clone and the PR publish use the network, and both happen outside the agent sandbox.
+- Local handoff execution requires `CODEX_APP_SERVER_TRANSPORT=stdio`; WebSocket transport is supported for normal model-backed turns but is rejected for workspace-write handoff turns because this process cannot sanitize an already-running WebSocket server environment.
 - Workspace-write turns run with a sanitized subprocess environment: backend and provider secrets (GitHub tokens, Azure keys, `OPENAI_API_KEY`, Infisical tokens, admin keys) are not forwarded. The `codex` CLI must be authenticated through its own credential store (`codex login`); API-key-only codex auth is not supported for local handoff execution.
 - Deletions and binary files are not published automatically; they are listed in the PR body and completion event instead.
 

--- a/docs/runbooks/LOCAL_DEMO_RUNBOOK.md
+++ b/docs/runbooks/LOCAL_DEMO_RUNBOOK.md
@@ -1,6 +1,6 @@
 # Local Demo Runbook (PipelineHealer)
 
-<!-- LAST_VERIFIED: 42e442f -->
+<!-- LAST_VERIFIED: b619406 -->
 
 This guide walks you through setting up PipelineHealer locally, triggering CI failures in a demo repo, and verifying the results on the dashboard.
 
@@ -260,7 +260,7 @@ Testing local Codex handoff on this machine:
 2. For a dry run that records changes without opening a PR, set `AGENT_HANDOFF_LOCAL_CODEX_OPEN_PR=false`.
 3. Open a failed activity, create a handoff session targeting Codex App Server with `send=true`, and watch the session timeline: `started_work`, then `pr_opened` and/or `completed` (or `failed` with the scrubbed error).
 4. To test auto-delegation, also set `AGENT_HANDOFF_AUTO_LOCAL=true` and let a remediation fail; one session per activity is created by `auto:orchestrator`.
-5. Local execution requires the `codex` CLI and `git` on this host and a GitHub token with contents and pull-request write access. With WebSocket transport, the Codex App Server must be loopback so it can see the cloned workspace.
+5. Local execution requires the `codex` CLI and `git` on this host, a GitHub token with contents and pull-request write access, and `CODEX_APP_SERVER_TRANSPORT=stdio`. WebSocket transport is rejected for local handoff execution because the backend cannot sanitize an already-running WebSocket server environment before handing it an untrusted workspace.
 
 Settings UI note:
 - Runtime policy now includes remediation PR auto-merge. The `merge_when_clean` strategy polls the generated PR head and merges only after GitHub reports the PR mergeable and checks are clean; `github_auto_merge` asks GitHub to manage the merge after branch requirements pass.


### PR DESCRIPTION
## Summary

Fixes the post-merge Codex P1 from PR #210: local Codex handoff execution no longer allows WebSocket transport, even for loopback URLs.

Workspace-write handoff turns run over untrusted cloned repositories. The stdio path can launch the Codex App Server subprocess with `sanitized_agent_env()`, but the WebSocket path talks to an already-running server whose process environment this backend cannot scrub. Local handoff now fails fast unless `CODEX_APP_SERVER_TRANSPORT=stdio`.

## Changes

- Reject WebSocket transport for local Codex handoff execution.
- Update the WebSocket regression test to prove loopback WebSocket is rejected too.
- Update runtime docs, demo runbook, and changelog to mark local handoff as stdio-only.
- Backfill changelog commit references needed by release preflight after PR #210 merged.

## Verification

- `cd backend && ../.venv/bin/python -m ruff check src tests -q`
- `cd backend && ../.venv/bin/pytest tests/test_agent_handoff.py -q` (33 passed)
- `cd backend && ../.venv/bin/python -m mypy src`
- `cd backend && ../.venv/bin/pytest -q` (421 passed, 2 existing warnings)
- `bash scripts/release_preflight.sh --allow-non-main`

Residual nuance: normal model-backed Codex App Server WebSocket transport remains supported. This restriction only applies to local handoff execution because it hands an untrusted workspace to the agent.
