### PR TITLE
fix: gate local Codex availability on stdio transport

### DIFF
--- a/backend/src/agents/local_handoff.py
+++ b/backend/src/agents/local_handoff.py
@@ -69,9 +69,13 @@ def local_codex_execution_available(settings: Any) -> bool:
     """Return whether local Codex execution may serve codex_app_server sessions.
 
     Any configured remote receiver wins, including the legacy webhook URL that
-    _target_handoff_url falls back to for the codex_app_server target.
+    _target_handoff_url falls back to for the codex_app_server target. The
+    transport must also support local workspace execution; otherwise sessions
+    would queue only to fail the same check in the executor.
     """
     if not bool(getattr(settings, "agent_handoff_local_codex_enabled", False)):
+        return False
+    if not _transport_supports_local_workspace(settings):
         return False
     remote_url = (
         str(getattr(settings, "codex_app_server_handoff_url", "") or "").strip()
@@ -245,12 +249,17 @@ class _ChangeSet:
         return bool(self.upserts or self.deleted or self.skipped)
 
 
-def _check_transport_supports_local_workspace(settings: Any) -> None:
-    """Reject transports this process cannot confine for untrusted workspaces."""
+def _transport_supports_local_workspace(settings: Any) -> bool:
+    """Return whether the transport can confine untrusted workspace execution."""
     transport = str(
         getattr(settings, "codex_app_server_transport", "stdio") or "stdio"
     ).strip().lower()
-    if transport != "websocket":
+    return transport != "websocket"
+
+
+def _check_transport_supports_local_workspace(settings: Any) -> None:
+    """Reject transports this process cannot confine for untrusted workspaces."""
+    if _transport_supports_local_workspace(settings):
         return
     raise RuntimeError(
         "Local Codex handoff execution requires stdio transport so the "

--- a/backend/tests/test_agent_handoff.py
+++ b/backend/tests/test_agent_handoff.py
@@ -1167,6 +1167,31 @@ async def test_local_codex_executor_rejects_websocket_transport(
 
 
 @pytest.mark.asyncio
+async def test_local_codex_unavailable_on_websocket_transport(
+    monkeypatch: pytest.MonkeyPatch,
+    _storage: InMemoryStorage,
+) -> None:
+    from src.agents import local_handoff
+    from src.config import get_settings
+
+    monkeypatch.setenv("CODEX_APP_SERVER_TRANSPORT", "websocket")
+    monkeypatch.setenv("CODEX_APP_SERVER_WS_URL", "ws://127.0.0.1:8787/api")
+    monkeypatch.setenv("AGENT_HANDOFF_AUTO_LOCAL", "true")
+    _local_codex_env(monkeypatch)
+
+    assert local_handoff.local_codex_execution_available(get_settings()) is False
+
+    activity_id = await _make_activity(_storage, 410)
+    activity = await _storage.get_activity(activity_id)
+    assert activity is not None
+    session = await local_handoff.create_auto_local_handoff(
+        activity=activity, storage=_storage
+    )
+    assert session is None
+    assert await _storage.list_handoff_sessions_for_activity(activity_id) == []
+
+
+@pytest.mark.asyncio
 async def test_auto_local_handoff_defers_to_legacy_webhook_url(
     monkeypatch: pytest.MonkeyPatch,
     _storage: InMemoryStorage,


### PR DESCRIPTION
## Summary

Addresses the unresolved Codex review finding on #211 ([comment](https://github.com/Canepro/pipelinehealer/pull/211#discussion_r3392402119)): when `CODEX_APP_SERVER_TRANSPORT=websocket` and local or auto handoff was enabled, `local_codex_execution_available()` still reported local execution as available. Sessions were persisted as queued, then the executor's stdio check failed them in the background, so every eligible remediation failure produced a doomed failed handoff.

## Changes

- Extract the transport check into `_transport_supports_local_workspace()` and use it from both `local_codex_execution_available()` (the API and auto-handoff gate) and `_check_transport_supports_local_workspace()` (the executor's defense-in-depth check).
- With WebSocket transport, the API path now falls through to record-only or webhook delivery and the auto path skips local handoff instead of queuing a session that cannot run.

## Tests

- New `test_local_codex_unavailable_on_websocket_transport`: availability is false under WebSocket transport and `create_auto_local_handoff()` creates no session.
- Full backend suite: 422 passed. Ruff and mypy clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)