### PR TITLE
feat: rework operator surfaces for clearer story and consistent labels

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -144,10 +144,10 @@ export default function Layout() {
 
           <div className="border-t border-[var(--ph-border-subtle)] px-5 py-4">
             <p className="text-xs font-medium text-[var(--ph-text)]">
-              OSS-first pipeline platform
+              Open-source pipeline remediation
             </p>
             <p className="mt-1 text-xs text-[var(--ph-muted)]">
-              GitHub Actions and Jenkins bridge today.
+              GitHub Actions and Jenkins bridge.
             </p>
             <div className="mt-3 border-t border-[var(--ph-border-subtle)] pt-3">
               <ReleaseStatus />

--- a/frontend/src/components/settings/AdminControlsForm.tsx
+++ b/frontend/src/components/settings/AdminControlsForm.tsx
@@ -107,23 +107,23 @@ const SETTINGS_SECTION_OPTIONS: Array<{
 }> = [
   {
     value: "runtime",
-    label: "1. Runtime Controls",
+    label: "1. Runtime controls",
     summary:
-      "Runtime Controls: set remediation behavior, repo scope, and operation mode first.",
+      "Set remediation behavior, repo scope, and operation mode first.",
     Icon: Zap,
   },
   {
     value: "intelligence",
-    label: "2. AI & Integrations",
+    label: "2. AI & integrations",
     summary:
-      "AI & Integrations: configure model providers, handoff, external diagnostics, and MCP policies.",
+      "Configure model providers, handoff, external diagnostics, and MCP policies.",
     Icon: Sparkles,
   },
   {
     value: "security",
-    label: "3. Security & Advanced",
+    label: "3. Security & advanced",
     summary:
-      "Security & Advanced: adjust auth posture, retries, limits, and low-level safeguards.",
+      "Adjust auth posture, retries, limits, and low-level safeguards.",
     Icon: Shield,
   },
 ];
@@ -745,7 +745,7 @@ export default function AdminControlsForm({
             <CardHeader className="pb-4">
               <div className="flex items-center gap-2">
                 <Zap className="h-5 w-5 text-[var(--ph-accent)]" />
-                <CardTitle>Healing Behavior</CardTitle>
+                <CardTitle>Healing behavior</CardTitle>
               </div>
               <p className="text-sm text-[var(--ph-muted)]">
                 Controls how PipelineHealer responds to pipeline failures.
@@ -1358,7 +1358,7 @@ export default function AdminControlsForm({
             <CardHeader className="pb-4">
               <div className="flex items-center gap-2">
                 <Sparkles className="h-5 w-5 text-[var(--ph-accent)]" />
-                <CardTitle>AI Configuration</CardTitle>
+                <CardTitle>AI configuration</CardTitle>
               </div>
               <p className="text-sm text-[var(--ph-muted)]">
                 Configure model provider and deployment for log analysis and
@@ -2404,7 +2404,7 @@ export default function AdminControlsForm({
             <CardHeader className="pb-4">
               <div className="flex items-center gap-2">
                 <Wrench className="h-5 w-5 text-[var(--ph-accent)]" />
-                <CardTitle>MCP Integration (Preview)</CardTitle>
+                <CardTitle>MCP integration (preview)</CardTitle>
               </div>
               <p className="text-sm text-[var(--ph-muted)]">
                 Foundation controls for provider-agnostic MCP tool integration.
@@ -2798,7 +2798,7 @@ export default function AdminControlsForm({
             <CardHeader className="pb-4">
               <div className="flex items-center gap-2">
                 <Shield className="h-5 w-5 text-[var(--ph-accent)]" />
-                <CardTitle>Repository Scope</CardTitle>
+                <CardTitle>Repository scope</CardTitle>
               </div>
               <p className="text-sm text-[var(--ph-muted)]">
                 {SETTING_DESCRIPTIONS.ph_allowed_repos}
@@ -2878,7 +2878,7 @@ export default function AdminControlsForm({
             <CardHeader className="pb-4">
               <div className="flex items-center gap-2">
                 <Wrench className="h-5 w-5 text-[var(--ph-accent)]" />
-                <CardTitle>External Diagnostics</CardTitle>
+                <CardTitle>External diagnostics</CardTitle>
               </div>
               <p className="text-sm text-[var(--ph-muted)]">
                 GitHub Agentic Workflows integration for enhanced CI failure

--- a/frontend/src/pages/Activities.tsx
+++ b/frontend/src/pages/Activities.tsx
@@ -19,7 +19,7 @@ import {
 } from '@/components/ui/select'
 
 const statusOptions = [
-  { value: '', label: 'All Statuses' },
+  { value: '', label: 'All statuses' },
   { value: 'completed', label: 'Completed' },
   { value: 'failed', label: 'Failed' },
   { value: 'pending', label: 'Pending' },
@@ -28,11 +28,11 @@ const statusOptions = [
 ]
 
 const failureTypeOptions = [
-  { value: '', label: 'All Types' },
+  { value: '', label: 'All types' },
   { value: 'dependency', label: 'Dependency' },
   { value: 'test', label: 'Test' },
   { value: 'lint', label: 'Lint' },
-  { value: 'build_config', label: 'Build Config' },
+  { value: 'build_config', label: 'Build config' },
   { value: 'timeout', label: 'Timeout' },
 ]
 
@@ -180,7 +180,7 @@ export default function Activities() {
         <div className="flex items-center gap-2">
           {focusedActivityId && (
             <>
-              <Badge variant="secondary">Focused View</Badge>
+              <Badge variant="secondary">Focused view</Badge>
               <Button
                 variant="ghost"
                 size="sm"
@@ -234,7 +234,7 @@ export default function Activities() {
               onValueChange={(value) => updateFilter('status', value === '__all__' ? '' : value)}
             >
               <SelectTrigger className="lg:w-52" aria-label="Filter by status">
-                <SelectValue placeholder="All Statuses" />
+                <SelectValue placeholder="All statuses" />
               </SelectTrigger>
               <SelectContent>
                 {statusOptions.map((option) => (
@@ -251,7 +251,7 @@ export default function Activities() {
               }
             >
               <SelectTrigger className="lg:w-52" aria-label="Filter by failure type">
-                <SelectValue placeholder="All Types" />
+                <SelectValue placeholder="All types" />
               </SelectTrigger>
               <SelectContent>
                 {failureTypeOptions.map((option) => (

--- a/frontend/src/pages/ControlCenter.tsx
+++ b/frontend/src/pages/ControlCenter.tsx
@@ -688,6 +688,7 @@ export default function ControlCenterPage() {
   const isApiAuthReady = useApiAuthReady();
   const [adminKeyInput, setAdminKeyInput] = useState("");
   const [adminKey, setAdminKey] = useState("");
+  const [showAuthPanel, setShowAuthPanel] = useState(false);
   const [useSessionAuth, setUseSessionAuth] = useState(false);
   const [activeSection, setActiveSection] =
     useState<ControlCenterSection>("overview");
@@ -1105,11 +1106,34 @@ export default function ControlCenterPage() {
         </div>
       </div>
 
+      {settings && !showAuthPanel ? (
+        <Card>
+          <CardContent className="flex flex-wrap items-center justify-between gap-3 py-4">
+            <div className="flex items-center gap-2 text-sm">
+              <KeyRound className="h-4 w-4 text-[var(--ph-accent)]" />
+              <span className="font-medium text-[var(--ph-text)]">
+                Admin access active
+              </span>
+              <span className="text-[var(--ph-muted)]">
+                via {sessionAuthActive ? "Entra session" : "admin key"} ·
+                read-only page
+              </span>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowAuthPanel(true)}
+            >
+              Change credentials
+            </Button>
+          </CardContent>
+        </Card>
+      ) : (
       <Card>
         <CardHeader className="pb-4">
           <div className="flex items-center gap-2">
             <KeyRound className="h-5 w-5 text-[var(--ph-accent)]" />
-            <CardTitle>Admin Access</CardTitle>
+            <CardTitle>Admin access</CardTitle>
           </div>
         </CardHeader>
         <CardContent>
@@ -1171,16 +1195,16 @@ export default function ControlCenterPage() {
               </>
             ) : (
               <>
-                Session login is disabled in this deployment (
-                <code className="font-mono">VITE_AUTH_MODE=none</code>). Use{" "}
-                <code className="font-mono">X-Admin-Key</code> or set{" "}
-                <code className="font-mono">VITE_AUTH_MODE=entra</code> in
-                frontend runtime env and redeploy env.
+                Session sign-in is disabled in this deployment. Authenticate
+                with the admin key, or enable Entra sign-in in the frontend
+                runtime configuration (
+                <code className="font-mono">VITE_AUTH_MODE=entra</code>).
               </>
             )}
           </p>
         </CardContent>
       </Card>
+      )}
 
       {sessionBootstrapPending && (
         <Card>
@@ -1250,10 +1274,10 @@ export default function ControlCenterPage() {
               >
                 <TabsList className="inline-flex h-auto min-h-0 w-full flex-wrap gap-1 rounded-lg border border-[var(--ph-border-subtle)] bg-[var(--ph-bg-elevated)]/40 p-1 sm:w-auto">
                   {[
-                    { value: "overview", label: "Governance Overview" },
-                    { value: "learning_ops", label: "Learning & Ops" },
-                    { value: "trust_ops", label: "Trust Ops" },
-                    { value: "audit", label: "Audit & Trace" },
+                    { value: "overview", label: "Governance" },
+                    { value: "learning_ops", label: "Learning" },
+                    { value: "trust_ops", label: "Trust" },
+                    { value: "audit", label: "Audit" },
                   ].map((tab) => (
                     <TabsTrigger
                       key={tab.value}
@@ -1267,13 +1291,13 @@ export default function ControlCenterPage() {
               </Tabs>
               <p className="mt-3 text-sm text-[var(--ph-muted)]">
                 {activeSection === "overview" &&
-                  "Overview: runtime posture, policy impact, model routing, and MCP policy effect."}
+                  "Runtime posture, policy impact, model routing, and MCP policy effect."}
                 {activeSection === "learning_ops" &&
-                  "Learning & Ops: candidate governance actions, readiness evidence, and investigation runbooks."}
+                  "Candidate governance actions, readiness evidence, and investigation runbooks."}
                 {activeSection === "trust_ops" &&
-                  "Trust Ops: operator review queue and compact trust metrics derived from recent activity and guided runs."}
+                  "Operator review queue and trust metrics derived from recent activity and guided runs."}
                 {activeSection === "audit" &&
-                  "Audit & Trace: recent settings changes with actor and request-id traceability."}
+                  "Recent settings changes with actor and request-id traceability."}
               </p>
             </CardContent>
           </Card>
@@ -1646,10 +1670,10 @@ export default function ControlCenterPage() {
                   </CardHeader>
                   <CardContent className="flex flex-wrap gap-2">
                     <Button asChild size="sm">
-                      <Link to="/app/settings">Open Settings</Link>
+                      <Link to="/app/settings">Open settings</Link>
                     </Button>
                     <Button asChild size="sm" variant="secondary">
-                      <Link to="/app/activities">Review Activities</Link>
+                      <Link to="/app/activities">Review activities</Link>
                     </Button>
                   </CardContent>
                 </Card>
@@ -2142,7 +2166,7 @@ export default function ControlCenterPage() {
                 onLoad={() => {
                   void refetchAudit();
                 }}
-                title="Audit Timeline"
+                title="Audit timeline"
                 description="Recent settings changes with actor and request trace. Use this as the primary governance feed."
                 defaultVisibleCount={5}
                 pageSize={5}
@@ -2152,15 +2176,15 @@ export default function ControlCenterPage() {
                 <CardHeader className="pb-2">
                   <CardTitle className="flex items-center gap-2 text-base">
                     <ScrollText className="h-4 w-4 text-[var(--ph-accent)]" />
-                    Next Actions
+                    Next actions
                   </CardTitle>
                 </CardHeader>
                 <CardContent className="flex flex-wrap gap-2">
                   <Button asChild size="sm">
-                    <Link to="/app/settings">Open Settings</Link>
+                    <Link to="/app/settings">Open settings</Link>
                   </Button>
                   <Button asChild size="sm" variant="secondary">
-                    <Link to="/app/activities">Review Activities</Link>
+                    <Link to="/app/activities">Review activities</Link>
                   </Button>
                 </CardContent>
               </Card>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -341,6 +341,12 @@ export default function Dashboard() {
     : "Unavailable";
 
   const showStatsLoading = statsLoading && !statsError;
+  const isColdStart =
+    !statsLoading &&
+    !statsError &&
+    !activitiesLoading &&
+    (stats?.total_runs_processed ?? 0) === 0 &&
+    (activities?.length ?? 0) === 0;
   const statsErrorMessage =
     statsError && statsErrorValue instanceof Error
       ? statsErrorValue.message
@@ -370,7 +376,7 @@ export default function Dashboard() {
           </div>
           <div>
             <h1 className="text-2xl font-semibold tracking-tight text-[var(--ph-text)]">
-              Pipeline Reliability Dashboard
+              Dashboard
             </h1>
             <p className="mt-1 max-w-2xl text-sm leading-relaxed text-[var(--ph-muted)]">
               Remediation throughput, safety posture, and external diagnostic
@@ -379,7 +385,7 @@ export default function Dashboard() {
             <div className="mt-3 flex flex-wrap items-center gap-2">
               <Button asChild size="sm">
                 <Link to="/app/activities">
-                  Review Activities
+                  Review activities
                   <ArrowRight className="h-4 w-4" />
                 </Link>
               </Button>
@@ -387,7 +393,7 @@ export default function Dashboard() {
                 <Link to="/app/control-center">Control Center</Link>
               </Button>
               <Button asChild size="sm" variant="ghost">
-                <Link to="/app/settings">Runtime Settings</Link>
+                <Link to="/app/settings">Settings</Link>
               </Button>
             </div>
           </div>
@@ -399,6 +405,38 @@ export default function Dashboard() {
           </span>
         </div>
       </div>
+
+      {statsError && (
+        <div className="rounded-lg border border-[var(--ph-warning-border)] bg-[var(--ph-warning-bg)] px-4 py-3 text-sm text-[var(--ph-warning)]">
+          Dashboard stats endpoint is unavailable: {statsErrorMessage}
+        </div>
+      )}
+
+      {isColdStart && (
+        <Card>
+          <CardContent className="flex flex-wrap items-center justify-between gap-4 py-5">
+            <div className="max-w-2xl">
+              <p className="text-sm font-semibold text-[var(--ph-text)]">
+                {EMPTY_STATES.activities.title}
+              </p>
+              <p className="mt-1 text-sm text-[var(--ph-muted)]">
+                {EMPTY_STATES.activities.body} Point a repository webhook at
+                PipelineHealer, or trigger a failure in the demo repository to
+                see the full healing flow.
+              </p>
+            </div>
+            <Button asChild size="sm" variant="secondary">
+              <a
+                href="https://github.com/Canepro/pipelinehealer-demo"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Open demo repo
+              </a>
+            </Button>
+          </CardContent>
+        </Card>
+      )}
 
       <section className="space-y-3">
         <h2 className="text-sm font-semibold uppercase tracking-[0.08em] text-[var(--ph-muted)]">
@@ -430,13 +468,13 @@ export default function Dashboard() {
               color="success"
             />
             <StatsCard
-              title="Safety Gated"
+              title="Safety gated"
               value={`${stats?.safety_blocked_remediations || 0} (${safetyGatedRate}%)`}
               icon={ShieldAlert}
               color="danger"
             />
             <StatsCard
-              title="Issue-Only"
+              title="Issue-only"
               value={`${stats?.issue_remediations || 0} (${issueRate}%)`}
               icon={FileText}
               color="warning"
@@ -482,57 +520,13 @@ export default function Dashboard() {
         </div>
       </section>
 
-      <Card>
-        <CardHeader className="pb-2">
-          <CardTitle className="text-base">Why Safety Gated</CardTitle>
-          <p className="text-sm text-[var(--ph-muted)]">
-            We create review-ready proposals when changes touch non-allowlisted
-            paths or require extra context.
-          </p>
-        </CardHeader>
-        <CardContent className="space-y-3 pt-0">
-          {safetyGateReasonCounts.length > 0 ? (
-            <div className="flex flex-wrap gap-2">
-              {safetyGateReasonCounts.map((item) => (
-                <div
-                  key={item.code}
-                  className="rounded-md border border-[var(--ph-border)] bg-[var(--ph-bg-elevated)] px-3 py-2 text-xs text-[var(--ph-text)]"
-                >
-                  <div className="font-semibold">
-                    {formatReasonLabel(item.code)} ({item.count})
-                  </div>
-                  <div className="mt-1 text-[var(--ph-muted)]">
-                    <span className="font-mono">{item.code}</span>
-                  </div>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div>
-              <p className="text-sm font-medium text-[var(--ph-text)]">
-                {EMPTY_STATES.safetyGated.title}
-              </p>
-              <p className="mt-1 text-sm text-[var(--ph-muted)]">
-                {EMPTY_STATES.safetyGated.body}
-              </p>
-            </div>
-          )}
-        </CardContent>
-      </Card>
-
-      {statsError && (
-        <div className="rounded-lg border border-[var(--ph-warning-border)] bg-[var(--ph-warning-bg)] px-4 py-3 text-sm text-[var(--ph-warning)]">
-          Dashboard stats endpoint is unavailable: {statsErrorMessage}
-        </div>
-      )}
-
       {/* Charts Row */}
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
         {/* Failure Types Pie Chart */}
         <Card>
           <CardHeader className="pb-2">
             <CardTitle className="text-base">
-              Failure Types (Last 30 Days)
+              Failure types (last 30 days)
             </CardTitle>
             <p className="text-sm text-[var(--ph-muted)]">
               Total failures observed:{" "}
@@ -601,17 +595,8 @@ export default function Dashboard() {
                 </PieChart>
               </ResponsiveContainer>
             ) : (
-              <div className="flex h-[250px] flex-col items-center justify-center gap-3 text-sm text-[var(--ph-muted)]">
-                <p>{EMPTY_STATES.activities.body}</p>
-                <Button asChild size="sm" variant="secondary">
-                  <a
-                    href="https://github.com/Canepro/pipelinehealer-demo"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    Open demo repo
-                  </a>
-                </Button>
+              <div className="flex h-[250px] items-center justify-center text-sm text-[var(--ph-muted)]">
+                <p>No failure data yet.</p>
               </div>
             )}
             {pieData.length > 0 && (
@@ -643,7 +628,7 @@ export default function Dashboard() {
         {/* Top Repositories Bar Chart */}
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-base">Top Repositories</CardTitle>
+            <CardTitle className="text-base">Top repositories</CardTitle>
             <p className="text-sm text-[var(--ph-muted)]">
               Most active repo:{" "}
               <span className="font-semibold text-[var(--ph-text)]">
@@ -715,17 +700,8 @@ export default function Dashboard() {
                 </BarChart>
               </ResponsiveContainer>
             ) : (
-              <div className="flex h-[250px] flex-col items-center justify-center gap-3 text-sm text-[var(--ph-muted)]">
-                <p>{EMPTY_STATES.activities.body}</p>
-                <Button asChild size="sm" variant="secondary">
-                  <a
-                    href="https://github.com/Canepro/pipelinehealer-demo"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    Open demo repo
-                  </a>
-                </Button>
+              <div className="flex h-[250px] items-center justify-center text-sm text-[var(--ph-muted)]">
+                <p>No repository data yet.</p>
               </div>
             )}
             {repoData.length > 0 && (
@@ -751,12 +727,50 @@ export default function Dashboard() {
         </Card>
       </div>
 
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">Why runs are safety gated</CardTitle>
+          <p className="text-sm text-[var(--ph-muted)]">
+            We create review-ready proposals when changes touch non-allowlisted
+            paths or require extra context.
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-3 pt-0">
+          {safetyGateReasonCounts.length > 0 ? (
+            <div className="flex flex-wrap gap-2">
+              {safetyGateReasonCounts.map((item) => (
+                <div
+                  key={item.code}
+                  className="rounded-md border border-[var(--ph-border)] bg-[var(--ph-bg-elevated)] px-3 py-2 text-xs text-[var(--ph-text)]"
+                >
+                  <div className="font-semibold">
+                    {formatReasonLabel(item.code)} ({item.count})
+                  </div>
+                  <div className="mt-1 text-[var(--ph-muted)]">
+                    <span className="font-mono">{item.code}</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div>
+              <p className="text-sm font-medium text-[var(--ph-text)]">
+                {EMPTY_STATES.safetyGated.title}
+              </p>
+              <p className="mt-1 text-sm text-[var(--ph-muted)]">
+                {EMPTY_STATES.safetyGated.body}
+              </p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
       {/* Explainability Snapshot */}
       <Card>
         <CardHeader className="pb-2">
           <CardTitle className="flex items-center gap-2 text-base">
             <SearchCheck className="h-4 w-4 text-[var(--ph-accent)]" />
-            Explainability Snapshot
+            Explainability snapshot
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -960,7 +974,7 @@ export default function Dashboard() {
       <section className="space-y-4">
         <div className="mb-4 flex items-center justify-between">
           <h2 className="text-lg font-semibold text-[var(--ph-text)]">
-            Recent Activities
+            Recent activities
           </h2>
           <Button asChild size="sm" variant="ghost">
             <Link to="/app/activities">View all</Link>

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -100,7 +100,7 @@ export default function Landing() {
               </a>
             </Button>
             <Button asChild size="sm">
-              <Link to="/app">Open App</Link>
+              <Link to="/app">Open control plane</Link>
             </Button>
           </div>
         </div>
@@ -116,8 +116,8 @@ export default function Landing() {
                 CI/CD failure control, remediation, and proof
               </div>
               <div className="space-y-4">
-                <h1 className="max-w-4xl break-words text-4xl font-semibold leading-[1.02] min-[360px]:text-5xl sm:text-6xl lg:text-7xl">
-                  PipelineHealer
+                <h1 className="max-w-4xl break-words text-4xl font-semibold leading-[1.05] min-[360px]:text-5xl sm:text-6xl">
+                  Failed pipelines, fixed under policy
                 </h1>
                 <p className="max-w-3xl text-lg leading-8 text-[var(--ph-muted)] sm:text-xl">
                   PipelineHealer watches failed CI/CD runs, diagnoses the
@@ -271,8 +271,8 @@ export default function Landing() {
                 text="See failure mix, recent activity, safety gates, and system posture at a glance."
               />
               <SurfaceRow
-                title="Activity Detail"
-                text="Trace diagnosis, remediation, handoff messages, external diagnostics, and verification on one incident."
+                title="Activities"
+                text="Trace diagnosis, remediation, handoff messages, external diagnostics, and verification on each incident."
               />
               <SurfaceRow
                 title="Settings"
@@ -296,7 +296,7 @@ export default function Landing() {
               <PrincipleRow text="Fix when evidence and policy allow it." />
               <PrincipleRow text="Fall back to a review issue when confidence is weak." />
               <PrincipleRow text="Keep external agent work attached to the PipelineHealer record." />
-              <PrincipleRow text="Treat Azure as the reference deployment, not the product boundary." />
+              <PrincipleRow text="Run on a provider-neutral core; Azure is the reference deployment, not a dependency." />
             </CardContent>
           </Card>
         </section>
@@ -309,10 +309,6 @@ function HeroBackdrop() {
   return (
     <div aria-hidden className="absolute inset-0">
       <div className="absolute inset-0 opacity-[0.09] [background-image:linear-gradient(var(--ph-border)_1px,transparent_1px),linear-gradient(90deg,var(--ph-border)_1px,transparent_1px)] [background-size:48px_48px]" />
-      <div className="absolute left-[6%] top-16 hidden h-20 w-52 rounded-lg border border-[var(--ph-border)] bg-[var(--ph-surface)]/68 shadow-[var(--ph-shadow-md)] md:block" />
-      <div className="absolute bottom-20 right-[8%] hidden h-24 w-64 rounded-lg border border-[var(--ph-border)] bg-[var(--ph-surface)]/72 shadow-[var(--ph-shadow-md)] lg:block" />
-      <div className="absolute right-[24%] top-28 hidden h-3 w-28 rounded-full bg-[var(--ph-accent-soft)] lg:block" />
-      <div className="absolute bottom-36 left-[24%] hidden h-3 w-36 rounded-full bg-[var(--ph-success-bg)] md:block" />
     </div>
   );
 }

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -39,6 +39,7 @@ export default function SettingsPage() {
   const isApiAuthReady = useApiAuthReady();
   const [adminKeyInput, setAdminKeyInput] = useState("");
   const [adminKey, setAdminKey] = useState("");
+  const [showAuthPanel, setShowAuthPanel] = useState(false);
   const [adminKeyScopeId, setAdminKeyScopeId] = useState<number | null>(null);
   const [useSessionAuth, setUseSessionAuth] = useState(false);
   const [newMcpRepoInput, setNewMcpRepoInput] = useState("");
@@ -480,11 +481,33 @@ export default function SettingsPage() {
       </div>
 
       {/* Admin access */}
+      {data && !showAuthPanel ? (
+        <Card>
+          <CardContent className="flex flex-wrap items-center justify-between gap-3 py-4">
+            <div className="flex items-center gap-2 text-sm">
+              <KeyRound className="h-4 w-4 text-[var(--ph-accent)]" />
+              <span className="font-medium text-[var(--ph-text)]">
+                Admin access active
+              </span>
+              <span className="text-[var(--ph-muted)]">
+                via {sessionAuthActive ? "Entra session" : "admin key"}
+              </span>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowAuthPanel(true)}
+            >
+              Change credentials
+            </Button>
+          </CardContent>
+        </Card>
+      ) : (
       <Card>
         <CardHeader className="pb-4">
           <div className="flex items-center gap-2">
             <KeyRound className="h-5 w-5 text-[var(--ph-accent)]" />
-            <CardTitle>Admin Access</CardTitle>
+            <CardTitle>Admin access</CardTitle>
           </div>
         </CardHeader>
         <CardContent>
@@ -545,17 +568,16 @@ export default function SettingsPage() {
               </>
             ) : (
               <>
-                Session login is disabled in this deployment (
-                <code className="font-mono">VITE_AUTH_MODE=none</code>). Use{" "}
-                <code className="font-mono">X-Admin-Key</code> or set frontend
-                runtime{" "}
-                <code className="font-mono">VITE_ENTRA_*</code> values and
-                redeploy env.
+                Session sign-in is disabled in this deployment. Authenticate
+                with the admin key, or enable Entra sign-in in the frontend
+                runtime configuration (
+                <code className="font-mono">VITE_AUTH_MODE=entra</code>).
               </>
             )}
           </p>
         </CardContent>
       </Card>
+      )}
 
       {sessionBootstrapPending && (
         <Card>
@@ -613,6 +635,36 @@ export default function SettingsPage() {
         <>
           <RuntimePolicyBanner data={data} />
 
+          <AdminControlsForm
+            data={data}
+            form={form}
+            setForm={setForm}
+            llmProviderHealth={llmProviderHealth}
+            isLlmHealthLoading={isLlmHealthLoading}
+            isLlmHealthError={isLlmHealthError}
+            llmHealthError={llmHealthError}
+            mcpProviderHealth={mcpProviderHealth}
+            isMcpHealthLoading={isMcpHealthLoading}
+            isMcpHealthError={isMcpHealthError}
+            mcpHealthError={mcpHealthError}
+            llmCapabilitySummary={llmCapabilitySummary}
+            hasUnsavedChanges={hasUnsavedChanges}
+            newRepoInput={newRepoInput}
+            setNewRepoInput={setNewRepoInput}
+            newMcpRepoInput={newMcpRepoInput}
+            setNewMcpRepoInput={setNewMcpRepoInput}
+            newHandoffHostInput={newHandoffHostInput}
+            setNewHandoffHostInput={setNewHandoffHostInput}
+            setGhAwWorkflowsInput={setGhAwWorkflowsInput}
+            setLastSavedForm={setLastSavedForm}
+            savePending={saveMutation.isPending}
+            saveError={
+              saveMutation.isError ? (saveMutation.error as Error) : null
+            }
+            saveSuccess={saveMutation.isSuccess}
+            onSave={handleSaveSettings}
+          />
+
           <div className="grid gap-4 xl:grid-cols-[minmax(0,340px)_minmax(0,1fr)] xl:items-start">
             <SetupChecklistCard status={data.setup_status} />
             <SecretSettingsCard
@@ -627,21 +679,6 @@ export default function SettingsPage() {
             />
           </div>
 
-          <Card>
-            <CardContent className="flex flex-wrap items-center justify-between gap-3 py-4">
-              <p className="text-sm text-[var(--ph-muted)]">
-                Runtime settings save immediately to durable storage. Environment values now act as explicit startup overrides.
-              </p>
-              <div className="flex flex-wrap gap-2">
-                <Button asChild size="sm" variant="secondary">
-                  <Link to="/app/control-center">Open Control Center</Link>
-                </Button>
-                <Button asChild size="sm" variant="ghost">
-                  <Link to="/app/activities">Review Activities</Link>
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
           <div className="grid gap-4 xl:grid-cols-[minmax(0,1.35fr)_360px] xl:items-stretch">
             <div className="space-y-4">
               <RuntimeWiringCard form={form} setForm={setForm} data={data} />
@@ -842,7 +879,8 @@ export default function SettingsPage() {
                         1. Authenticate and confirm the current runtime posture.
                       </li>
                       <li>
-                        2. Change mutable controls in the section tabs below.
+                        2. Change controls in the section tabs at the top of
+                        this page.
                       </li>
                       <li>
                         3. Save once to apply and persist runtime changes.
@@ -858,35 +896,22 @@ export default function SettingsPage() {
             </div>
           </div>
 
-          <AdminControlsForm
-            data={data}
-            form={form}
-            setForm={setForm}
-            llmProviderHealth={llmProviderHealth}
-            isLlmHealthLoading={isLlmHealthLoading}
-            isLlmHealthError={isLlmHealthError}
-            llmHealthError={llmHealthError}
-            mcpProviderHealth={mcpProviderHealth}
-            isMcpHealthLoading={isMcpHealthLoading}
-            isMcpHealthError={isMcpHealthError}
-            mcpHealthError={mcpHealthError}
-            llmCapabilitySummary={llmCapabilitySummary}
-            hasUnsavedChanges={hasUnsavedChanges}
-            newRepoInput={newRepoInput}
-            setNewRepoInput={setNewRepoInput}
-            newMcpRepoInput={newMcpRepoInput}
-            setNewMcpRepoInput={setNewMcpRepoInput}
-            newHandoffHostInput={newHandoffHostInput}
-            setNewHandoffHostInput={setNewHandoffHostInput}
-            setGhAwWorkflowsInput={setGhAwWorkflowsInput}
-            setLastSavedForm={setLastSavedForm}
-            savePending={saveMutation.isPending}
-            saveError={
-              saveMutation.isError ? (saveMutation.error as Error) : null
-            }
-            saveSuccess={saveMutation.isSuccess}
-            onSave={handleSaveSettings}
-          />
+          <Card>
+            <CardContent className="flex flex-wrap items-center justify-between gap-3 py-4">
+              <p className="text-sm text-[var(--ph-muted)]">
+                Runtime settings save immediately to durable storage.
+                Environment values act as explicit startup overrides.
+              </p>
+              <div className="flex flex-wrap gap-2">
+                <Button asChild size="sm" variant="secondary">
+                  <Link to="/app/control-center">Open Control Center</Link>
+                </Button>
+                <Button asChild size="sm" variant="ghost">
+                  <Link to="/app/activities">Review activities</Link>
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
         </>
       )}
     </div>


### PR DESCRIPTION
## Summary

Enterprise-polish pass over the landing page, Dashboard, Activities, Control Center, and Settings, driven by a rendered audit of all four surfaces (1280 and 375 widths, dark and light modes, authenticated and cold-start states).

## What changed

**Settings, storytelling fix.** The page buried its only editable surface beneath four screens of read-only posture summaries. The controls form now sits directly under the active-policy banner; the setup checklist, secrets, and posture summaries follow it. The operator-workflow copy was updated to match the new order.

**Admin access, both gated pages.** After authentication the full credential card (input row plus env-var hints) collapses to a one-line "Admin access active via admin key / Entra session" bar with a Change credentials button. The pre-auth helper copy drops `VITE_*` jargon from the primary line.

**Dashboard.** The stats-error banner moves above the stats it invalidates. A single onboarding card with one demo-repo link replaces the same empty-state sentence repeated four times (with two duplicate buttons). The "Why runs are safety gated" explainer moves below the charts instead of occupying the third full-width slot with no data. The h1 is now "Dashboard", matching the nav.

**Landing.** The hero headline now states the value ("Failed pipelines, fixed under policy") instead of repeating the brand name already in the header. The decorative fake panels and pills behind the hero are removed. Header and hero CTAs both read "Open control plane". The surfaces list says "Activities" to match the nav.

**Labels.** Sentence case across section headers and buttons (Failure types, Top repositories, Recent activities, Healing behavior, AI configuration, Repository scope, External diagnostics, Admin access, Audit timeline, filter options). Nav and in-page links agree ("Settings", not "Runtime Settings"). Control Center tabs shorten to Governance / Learning / Trust / Audit with the redundant name prefix removed from descriptions. Sidebar footer drops "today" roadmap wording.

## Verification

- `tsc --noEmit`, `eslint --max-warnings 0`, `vitest` (19 passed), all clean.
- Rendered checks via dev preview against the live backend (dev auth mode): all four pages plus landing at 1280 and 375, dark and light schemes, cold-start empty states and authenticated states.

## Removed in this pass

Fake hero backdrop panels, three duplicate empty-state blocks and two duplicate demo-repo buttons on Dashboard, the redundant tab-name prefixes in Control Center descriptions, and env-var jargon from primary auth copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)