### PR TITLE
chore(azure): rightsize dev container apps

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -31,6 +31,86 @@ param frontendImageName string = 'pipelinehealer-frontend'
 @description('Image tag for backend/frontend images')
 param imageTag string = 'latest'
 
+@description('Backend Container App resources. Consumption-plan CPU and memory are constrained to supported pairs.')
+@allowed([
+  {
+    cpu: '0.25'
+    memory: '0.5Gi'
+  }
+  {
+    cpu: '0.5'
+    memory: '1Gi'
+  }
+  {
+    cpu: '0.75'
+    memory: '1.5Gi'
+  }
+  {
+    cpu: '1'
+    memory: '2Gi'
+  }
+  {
+    cpu: '1.25'
+    memory: '2.5Gi'
+  }
+  {
+    cpu: '1.5'
+    memory: '3Gi'
+  }
+  {
+    cpu: '1.75'
+    memory: '3.5Gi'
+  }
+  {
+    cpu: '2'
+    memory: '4Gi'
+  }
+])
+param backendResources object = {
+  cpu: '1'
+  memory: '2Gi'
+}
+
+@description('Frontend Container App resources. Consumption-plan CPU and memory are constrained to supported pairs.')
+@allowed([
+  {
+    cpu: '0.25'
+    memory: '0.5Gi'
+  }
+  {
+    cpu: '0.5'
+    memory: '1Gi'
+  }
+  {
+    cpu: '0.75'
+    memory: '1.5Gi'
+  }
+  {
+    cpu: '1'
+    memory: '2Gi'
+  }
+  {
+    cpu: '1.25'
+    memory: '2.5Gi'
+  }
+  {
+    cpu: '1.5'
+    memory: '3Gi'
+  }
+  {
+    cpu: '1.75'
+    memory: '3.5Gi'
+  }
+  {
+    cpu: '2'
+    memory: '4Gi'
+  }
+])
+param frontendResources object = {
+  cpu: '0.5'
+  memory: '1Gi'
+}
+
 @description('Storage backend mode exposed to the backend. Empty keeps the app default: memory in dev, Cosmos DB otherwise.')
 @allowed([
   ''
@@ -452,8 +532,8 @@ resource backendApp 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'backend'
           image: backendImage
           resources: {
-            cpu: json('1')
-            memory: '2Gi'
+            cpu: json(backendResources.cpu)
+            memory: backendResources.memory
           }
           env: [
             {
@@ -617,8 +697,8 @@ resource frontendApp 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'frontend'
           image: frontendImage
           resources: {
-            cpu: json('0.5')
-            memory: '1Gi'
+            cpu: json(frontendResources.cpu)
+            memory: frontendResources.memory
           }
           env: [
             {

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -10,6 +10,14 @@ param frontendContainerAppName = readEnvironmentVariable('PH_FRONTEND_APP', 'pip
 param backendImageName = 'pipelinehealer-backend'
 param frontendImageName = 'pipelinehealer-frontend'
 param imageTag = 'latest'
+param backendResources = {
+  cpu: '0.5'
+  memory: '1Gi'
+}
+param frontendResources = {
+  cpu: '0.25'
+  memory: '0.5Gi'
+}
 param apiAuthKey = readEnvironmentVariable('API_AUTH_KEY', 'replace_me_api_auth_key')
 param adminApiKey = readEnvironmentVariable('ADMIN_API_KEY', 'replace_me_admin_api_key')
 param githubWebhookSecret = readEnvironmentVariable('GITHUB_WEBHOOK_SECRET', 'replace_me_webhook_secret')

--- a/infra/main.prod.bicepparam
+++ b/infra/main.prod.bicepparam
@@ -10,6 +10,14 @@ param frontendContainerAppName = readEnvironmentVariable('PH_FRONTEND_APP', 'pip
 param backendImageName = 'pipelinehealer-backend'
 param frontendImageName = 'pipelinehealer-frontend'
 param imageTag = readEnvironmentVariable('RELEASE_VERSION', 'latest')
+param backendResources = {
+  cpu: '1'
+  memory: '2Gi'
+}
+param frontendResources = {
+  cpu: '0.5'
+  memory: '1Gi'
+}
 param storageMode = 'cosmos'
 param createCosmosDb = false
 param cosmosDbEndpointOverride = readEnvironmentVariable('COSMOS_DB_ENDPOINT', '')


### PR DESCRIPTION
## Summary\n\n- model Container Apps CPU and memory as constrained Consumption-plan pairs\n- set the development backend to 0.5 vCPU / 1 GiB\n- set the development frontend to 0.25 vCPU / 0.5 GiB\n- pin production at the existing 1 vCPU / 2 GiB backend and 0.5 vCPU / 1 GiB frontend allocations\n- preserve scale-to-zero defaults\n\n## Verification\n\n- {
  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
  "contentVersion": "1.0.0.0",
  "metadata": {
    "_generator": {
      "name": "bicep",
      "version": "0.43.8.12551",
      "templateHash": "2285853720672779675"
    }
  },
  "parameters": {
    "location": {
      "type": "string",
      "defaultValue": "[resourceGroup().location]",
      "metadata": {
        "description": "The location for all resources"
      }
    },
    "environmentName": {
      "type": "string",
      "defaultValue": "dev",
      "metadata": {
        "description": "Environment name (dev, staging, prod)"
      }
    },
    "baseName": {
      "type": "string",
      "defaultValue": "pipelinehealer",
      "metadata": {
        "description": "Base name for all resources"
      }
    },
    "acrName": {
      "type": "string",
      "defaultValue": "pipelinehealeracr",
      "metadata": {
        "description": "Azure Container Registry name (global unique, lowercase alphanumeric)"
      }
    },
    "containerAppsEnvironmentName": {
      "type": "string",
      "defaultValue": "cae-pipelinehealer-dev",
      "metadata": {
        "description": "Container Apps environment name"
      }
    },
    "backendContainerAppName": {
      "type": "string",
      "defaultValue": "pipelinehealer-backend-dev",
      "metadata": {
        "description": "Backend Container App name"
      }
    },
    "frontendContainerAppName": {
      "type": "string",
      "defaultValue": "pipelinehealer-frontend-dev",
      "metadata": {
        "description": "Frontend Container App name"
      }
    },
    "backendImageName": {
      "type": "string",
      "defaultValue": "pipelinehealer-backend",
      "metadata": {
        "description": "Backend image repository name in ACR"
      }
    },
    "frontendImageName": {
      "type": "string",
      "defaultValue": "pipelinehealer-frontend",
      "metadata": {
        "description": "Frontend image repository name in ACR"
      }
    },
    "imageTag": {
      "type": "string",
      "defaultValue": "latest",
      "metadata": {
        "description": "Image tag for backend/frontend images"
      }
    },
    "backendResources": {
      "type": "object",
      "defaultValue": {
        "cpu": "1",
        "memory": "2Gi"
      },
      "allowedValues": [
        {
          "cpu": "0.25",
          "memory": "0.5Gi"
        },
        {
          "cpu": "0.5",
          "memory": "1Gi"
        },
        {
          "cpu": "0.75",
          "memory": "1.5Gi"
        },
        {
          "cpu": "1",
          "memory": "2Gi"
        },
        {
          "cpu": "1.25",
          "memory": "2.5Gi"
        },
        {
          "cpu": "1.5",
          "memory": "3Gi"
        },
        {
          "cpu": "1.75",
          "memory": "3.5Gi"
        },
        {
          "cpu": "2",
          "memory": "4Gi"
        }
      ],
      "metadata": {
        "description": "Backend Container App resources. Consumption-plan CPU and memory are constrained to supported pairs."
      }
    },
    "frontendResources": {
      "type": "object",
      "defaultValue": {
        "cpu": "0.5",
        "memory": "1Gi"
      },
      "allowedValues": [
        {
          "cpu": "0.25",
          "memory": "0.5Gi"
        },
        {
          "cpu": "0.5",
          "memory": "1Gi"
        },
        {
          "cpu": "0.75",
          "memory": "1.5Gi"
        },
        {
          "cpu": "1",
          "memory": "2Gi"
        },
        {
          "cpu": "1.25",
          "memory": "2.5Gi"
        },
        {
          "cpu": "1.5",
          "memory": "3Gi"
        },
        {
          "cpu": "1.75",
          "memory": "3.5Gi"
        },
        {
          "cpu": "2",
          "memory": "4Gi"
        }
      ],
      "metadata": {
        "description": "Frontend Container App resources. Consumption-plan CPU and memory are constrained to supported pairs."
      }
    },
    "storageMode": {
      "type": "string",
      "defaultValue": "",
      "allowedValues": [
        "",
        "memory",
        "cosmos",
        "postgres"
      ],
      "metadata": {
        "description": "Storage backend mode exposed to the backend. Empty keeps the app default: memory in dev, Cosmos DB otherwise."
      }
    },
    "createCosmosDb": {
      "type": "bool",
      "defaultValue": true,
      "metadata": {
        "description": "Create a managed Cosmos DB account and containers. Disable when production must preserve and use an existing Cosmos DB account."
      }
    },
    "cosmosDbDatabaseName": {
      "type": "string",
      "defaultValue": "pipelinehealer",
      "metadata": {
        "description": "Cosmos DB database name used by PipelineHealer."
      }
    },
    "cosmosDbEndpointOverride": {
      "type": "string",
      "defaultValue": "",
      "metadata": {
        "description": "Existing Cosmos DB endpoint override. Leave empty to use the Cosmos account created by this deployment."
      }
    },
    "createAzureOpenAi": {
      "type": "bool",
      "defaultValue": true,
      "metadata": {
        "description": "Create a managed Azure AI/OpenAI account and model deployment. Disable when an external provider such as Codex App Server is the production model route."
      }
    },
    "azureOpenAiAccountKind": {
      "type": "string",
      "defaultValue": "AIServices",
      "allowedValues": [
        "AIServices",
        "OpenAI"
      ],
      "metadata": {
        "description": "Managed Azure AI/OpenAI account kind when createAzureOpenAi is true."
      }
    },
    "azureOpenAiDeploymentName": {
      "type": "string",
      "defaultValue": "gpt-5.4",
      "metadata": {
        "description": "Azure AI/OpenAI deployment name exposed to the backend when createAzureOpenAi is true, or an existing deployment name when using an external account."
      }
    },
    "azureOpenAiModelName": {
      "type": "string",
      "defaultValue": "gpt-5.4",
      "metadata": {
        "description": "Azure AI/OpenAI base model name for the managed deployment."
      }
    },
    "azureOpenAiModelVersion": {
      "type": "string",
      "defaultValue": "2026-03-05",
      "metadata": {
        "description": "Azure AI/OpenAI model version for the managed deployment."
      }
    },
    "azureOpenAiDeploymentCapacity": {
      "type": "int",
      "defaultValue": 100,
      "metadata": {
        "description": "Azure AI/OpenAI deployment capacity for the managed deployment."
      }
    },
    "azureOpenAiDeploymentSkuName": {
      "type": "string",
      "defaultValue": "GlobalStandard",
      "allowedValues": [
        "Standard",
        "GlobalStandard",
        "DataZoneStandard",
        "ProvisionedManaged"
      ],
      "metadata": {
        "description": "Azure AI/OpenAI deployment SKU for the managed model."
      }
    },
    "azureOpenAiEndpoint": {
      "type": "string",
      "defaultValue": "",
      "metadata": {
        "description": "Existing Azure AI/OpenAI endpoint to expose when createAzureOpenAi is false. Leave empty when the selected LLM provider does not need Azure OpenAI."
      }
    },
    "llmProvider": {
      "type": "string",
      "defaultValue": "azure_openai",
      "allowedValues": [
        "azure_openai",
        "openai_compatible",
        "codex_app_server",
        "custom"
      ],
      "metadata": {
        "description": "Backend LLM provider route."
      }
    },
    "codexAppServerTransport": {
      "type": "string",
      "defaultValue": "stdio",
      "allowedValues": [
        "stdio",
        "websocket"
      ],
      "metadata": {
        "description": "Codex App Server transport used when llmProvider is codex_app_server."
      }
    },
    "codexAppServerCommand": {
      "type": "string",
      "defaultValue": "codex app-server",
      "metadata": {
        "description": "Command used when Codex App Server transport is stdio."
      }
    },
    "codexAppServerModel": {
      "type": "string",
      "defaultValue": "gpt-5.4",
      "metadata": {
        "description": "Codex model requested from Codex App Server."
      }
    },
    "codexAppServerTurnTimeoutMs": {
      "type": "int",
      "defaultValue": 120000,
      "metadata": {
        "description": "Codex App Server turn timeout in milliseconds."
      }
    },
    "codexAppServerWsUrl": {
      "type": "string",
      "defaultValue": "",
      "metadata": {
        "description": "Codex App Server WebSocket URL used when transport is websocket."
      }
    },
    "codexAppServerWsAllowRemote": {
      "type": "bool",
      "defaultValue": false,
      "metadata": {
        "description": "Allow non-loopback Codex App Server WebSocket URLs. Required for ACA to call an external bridge."
      }
    },
    "codexAppServerWsBearerToken": {
      "type": "securestring",
      "defaultValue": "",
      "metadata": {
        "description": "Optional bearer token for the Codex App Server WebSocket bridge."
      }
    },
    "apiAuthKey": {
      "type": "securestring",
      "defaultValue": "",
      "metadata": {
        "description": "API key for X-API-Key protected /api/* routes"
      }
    },
    "authMode": {
      "type": "string",
      "defaultValue": "api_key",
      "allowedValues": [
        "api_key",
        "entra",
        "hybrid"
      ],
      "metadata": {
        "description": "Backend authentication mode for /api routes."
      }
    },
    "entraTenantId": {
      "type": "string",
      "defaultValue": "",
      "metadata": {
        "description": "Microsoft Entra tenant ID for backend bearer-token validation."
      }
    },
    "entraClientId": {
      "type": "string",
      "defaultValue": "",
      "metadata": {
        "description": "Microsoft Entra API app client ID used for backend token audience defaults."
      }
    },
    "entraAllowedAudiences": {
      "type": "string",
      "defaultValue": "",
      "metadata": {
        "description": "Optional accepted JWT audience values for Entra bearer tokens."
      }
    },
    "entraAdminRoles": {
      "type": "string",
      "defaultValue": "PipelineHealer.Admin",
      "metadata": {
        "description": "Accepted Entra app-role or scope values for admin-only settings endpoints."
      }
    },
    "frontendAuthMode": {
      "type": "string",
      "defaultValue": "none",
      "allowedValues": [
        "none",
        "entra"
      ],
      "metadata": {
        "description": "Frontend session auth mode."
      }
    },
    "frontendEntraTenantId": {
      "type": "string",
      "defaultValue": "",
      "metadata": {
        "description": "Frontend Microsoft Entra tenant ID."
      }
    },
    "frontendEntraClientId": {
      "type": "string",
      "defaultValue": "",
      "metadata": {
        "description": "Frontend Microsoft Entra SPA client ID."
      }
    },
    "frontendEntraAuthority": {
      "type": "string",
      "defaultValue": "",
      "metadata": {
        "description": "Frontend Microsoft Entra authority URL."
      }
    },
    "frontendEntraApiScope": {
      "type": "string",
      "defaultValue": "",
      "metadata": {
        "description": "Frontend Microsoft Entra API access scope."
      }
    },
    "frontendEntraRedirectUri": {
      "type": "string",
      "defaultValue": "",
      "metadata": {
        "description": "Frontend Microsoft Entra redirect URI."
      }
    },
    "frontendEntraPostLogoutRedirectUri": {
      "type": "string",
      "defaultValue": "",
      "metadata": {
        "description": "Frontend Microsoft Entra post-logout redirect URI."
      }
    },
    "adminApiKey": {
      "type": "securestring",
      "defaultValue": "",
      "metadata": {
        "description": "Admin API key for X-Admin-Key protected /api/settings* routes"
      }
    },
    "githubWebhookSecret": {
      "type": "securestring",
      "defaultValue": "",
      "metadata": {
        "description": "GitHub webhook secret used to validate webhook signatures"
      }
    },
    "githubPersonalAccessToken": {
      "type": "securestring",
      "defaultValue": "",
      "metadata": {
        "description": "GitHub PAT for API access (leave empty when using GitHub App auth only)"
      }
    },
    "acrPullIdentityName": {
      "type": "string",
      "defaultValue": "id-pipelinehealer-acrpull",
      "metadata": {
        "description": "User-assigned identity name used by Container Apps to pull from ACR"
      }
    }
  },
  "variables": {
    "uniqueSuffix": "[uniqueString(resourceGroup().id)]",
    "resourceBaseName": "[format('{0}{1}', parameters('baseName'), parameters('environmentName'))]",
    "backendImage": "[format('{0}.azurecr.io/{1}:{2}', parameters('acrName'), parameters('backendImageName'), parameters('imageTag'))]",
    "frontendImage": "[format('{0}.azurecr.io/{1}:{2}', parameters('acrName'), parameters('frontendImageName'), parameters('imageTag'))]",
    "keyVaultName": "[take(format('{0}kv{1}', parameters('baseName'), variables('uniqueSuffix')), 24)]"
  },
  "resources": [
    {
      "condition": "[parameters('createAzureOpenAi')]",
      "type": "Microsoft.CognitiveServices/accounts",
      "apiVersion": "2024-10-01",
      "name": "[format('{0}-openai-{1}', variables('resourceBaseName'), variables('uniqueSuffix'))]",
      "location": "[parameters('location')]",
      "kind": "[parameters('azureOpenAiAccountKind')]",
      "sku": {
        "name": "S0"
      },
      "properties": {
        "customSubDomainName": "[format('{0}-openai-{1}', variables('resourceBaseName'), variables('uniqueSuffix'))]",
        "publicNetworkAccess": "Enabled"
      }
    },
    {
      "condition": "[parameters('createAzureOpenAi')]",
      "type": "Microsoft.CognitiveServices/accounts/deployments",
      "apiVersion": "2024-10-01",
      "name": "[format('{0}/{1}', format('{0}-openai-{1}', variables('resourceBaseName'), variables('uniqueSuffix')), parameters('azureOpenAiDeploymentName'))]",
      "sku": {
        "name": "[parameters('azureOpenAiDeploymentSkuName')]",
        "capacity": "[parameters('azureOpenAiDeploymentCapacity')]"
      },
      "properties": {
        "model": {
          "format": "OpenAI",
          "name": "[parameters('azureOpenAiModelName')]",
          "version": "[parameters('azureOpenAiModelVersion')]"
        }
      },
      "dependsOn": [
        "[resourceId('Microsoft.CognitiveServices/accounts', format('{0}-openai-{1}', variables('resourceBaseName'), variables('uniqueSuffix')))]"
      ]
    },
    {
      "condition": "[parameters('createCosmosDb')]",
      "type": "Microsoft.DocumentDB/databaseAccounts",
      "apiVersion": "2024-05-15",
      "name": "[format('{0}-cosmos-{1}', variables('resourceBaseName'), variables('uniqueSuffix'))]",
      "location": "[parameters('location')]",
      "kind": "GlobalDocumentDB",
      "properties": {
        "databaseAccountOfferType": "Standard",
        "consistencyPolicy": {
          "defaultConsistencyLevel": "Session"
        },
        "locations": [
          {
            "locationName": "[parameters('location')]",
            "failoverPriority": 0,
            "isZoneRedundant": false
          }
        ],
        "capabilities": [
          {
            "name": "EnableServerless"
          }
        ]
      }
    },
    {
      "condition": "[parameters('createCosmosDb')]",
      "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases",
      "apiVersion": "2024-05-15",
      "name": "[format('{0}/{1}', format('{0}-cosmos-{1}', variables('resourceBaseName'), variables('uniqueSuffix')), parameters('cosmosDbDatabaseName'))]",
      "properties": {
        "resource": {
          "id": "[parameters('cosmosDbDatabaseName')]"
        }
      },
      "dependsOn": [
        "[resourceId('Microsoft.DocumentDB/databaseAccounts', format('{0}-cosmos-{1}', variables('resourceBaseName'), variables('uniqueSuffix')))]"
      ]
    },
    {
      "condition": "[parameters('createCosmosDb')]",
      "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers",
      "apiVersion": "2024-05-15",
      "name": "[format('{0}/{1}/{2}', format('{0}-cosmos-{1}', variables('resourceBaseName'), variables('uniqueSuffix')), parameters('cosmosDbDatabaseName'), 'activities')]",
      "properties": {
        "resource": {
          "id": "activities",
          "partitionKey": {
            "paths": [
              "/repositoryId"
            ],
            "kind": "Hash"
          },
          "indexingPolicy": {
            "automatic": true,
            "indexingMode": "consistent"
          }
        }
      },
      "dependsOn": [
        "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', format('{0}-cosmos-{1}', variables('resourceBaseName'), variables('uniqueSuffix')), parameters('cosmosDbDatabaseName'))]"
      ]
    },
    {
      "condition": "[parameters('createCosmosDb')]",
      "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers",
      "apiVersion": "2024-05-15",
      "name": "[format('{0}/{1}/{2}', format('{0}-cosmos-{1}', variables('resourceBaseName'), variables('uniqueSuffix')), parameters('cosmosDbDatabaseName'), 'workflow_runs')]",
      "properties": {
        "resource": {
          "id": "workflow_runs",
          "partitionKey": {
            "paths": [
              "/repositoryId"
            ],
            "kind": "Hash"
          }
        }
      },
      "dependsOn": [
        "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', format('{0}-cosmos-{1}', variables('resourceBaseName'), variables('uniqueSuffix')), parameters('cosmosDbDatabaseName'))]"
      ]
    },
    {
      "type": "Microsoft.OperationalInsights/workspaces",
      "apiVersion": "2023-09-01",
      "name": "[format('{0}-logs-{1}', variables('resourceBaseName'), variables('uniqueSuffix'))]",
      "location": "[parameters('location')]",
      "properties": {
        "sku": {
          "name": "PerGB2018"
        },
        "retentionInDays": 30
      }
    },
    {
      "type": "Microsoft.Insights/components",
      "apiVersion": "2020-02-02",
      "name": "[format('{0}-insights-{1}', variables('resourceBaseName'), variables('uniqueSuffix'))]",
      "location": "[parameters('location')]",
      "kind": "web",
      "properties": {
        "Application_Type": "web",
        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', format('{0}-logs-{1}', variables('resourceBaseName'), variables('uniqueSuffix')))]"
      },
      "dependsOn": [
        "[resourceId('Microsoft.OperationalInsights/workspaces', format('{0}-logs-{1}', variables('resourceBaseName'), variables('uniqueSuffix')))]"
      ]
    },
    {
      "type": "Microsoft.KeyVault/vaults",
      "apiVersion": "2023-07-01",
      "name": "[variables('keyVaultName')]",
      "location": "[parameters('location')]",
      "properties": {
        "sku": {
          "family": "A",
          "name": "standard"
        },
        "tenantId": "[subscription().tenantId]",
        "enableRbacAuthorization": true,
        "enableSoftDelete": true,
        "softDeleteRetentionInDays": 7
      }
    },
    {
      "type": "Microsoft.ContainerRegistry/registries",
      "apiVersion": "2023-07-01",
      "name": "[parameters('acrName')]",
      "location": "[parameters('location')]",
      "sku": {
        "name": "Basic"
      },
      "properties": {
        "adminUserEnabled": false,
        "publicNetworkAccess": "Enabled"
      }
    },
    {
      "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
      "apiVersion": "2023-01-31",
      "name": "[parameters('acrPullIdentityName')]",
      "location": "[parameters('location')]"
    },
    {
      "type": "Microsoft.Authorization/roleAssignments",
      "apiVersion": "2022-04-01",
      "scope": "[resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName'))]",
      "name": "[guid(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('acrPullIdentityName')), resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), 'acrpull')]",
      "properties": {
        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')]",
        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('acrPullIdentityName')), '2023-01-31').principalId]",
        "principalType": "ServicePrincipal"
      },
      "dependsOn": [
        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('acrPullIdentityName'))]",
        "[resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName'))]"
      ]
    },
    {
      "type": "Microsoft.App/managedEnvironments",
      "apiVersion": "2024-03-01",
      "name": "[parameters('containerAppsEnvironmentName')]",
      "location": "[parameters('location')]",
      "properties": {
        "appLogsConfiguration": {
          "destination": "log-analytics",
          "logAnalyticsConfiguration": {
            "customerId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', format('{0}-logs-{1}', variables('resourceBaseName'), variables('uniqueSuffix'))), '2023-09-01').customerId]",
            "sharedKey": "[listKeys(resourceId('Microsoft.OperationalInsights/workspaces', format('{0}-logs-{1}', variables('resourceBaseName'), variables('uniqueSuffix'))), '2023-09-01').primarySharedKey]"
          }
        }
      },
      "dependsOn": [
        "[resourceId('Microsoft.OperationalInsights/workspaces', format('{0}-logs-{1}', variables('resourceBaseName'), variables('uniqueSuffix')))]"
      ]
    },
    {
      "type": "Microsoft.App/containerApps",
      "apiVersion": "2024-03-01",
      "name": "[parameters('backendContainerAppName')]",
      "location": "[parameters('location')]",
      "identity": {
        "type": "SystemAssigned,UserAssigned",
        "userAssignedIdentities": {
          "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('acrPullIdentityName')))]": {}
        }
      },
      "properties": {
        "managedEnvironmentId": "[resourceId('Microsoft.App/managedEnvironments', parameters('containerAppsEnvironmentName'))]",
        "configuration": {
          "ingress": {
            "external": true,
            "targetPort": 8000,
            "transport": "auto"
          },
          "registries": [
            {
              "server": "[reference(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), '2023-07-01').loginServer]",
              "identity": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('acrPullIdentityName'))]"
            }
          ],
          "secrets": "[concat(createArray(createObject('name', 'api-auth-key', 'value', parameters('apiAuthKey')), createObject('name', 'admin-api-key', 'value', parameters('adminApiKey')), createObject('name', 'github-webhook-secret', 'value', parameters('githubWebhookSecret'))), if(empty(parameters('githubPersonalAccessToken')), createArray(), createArray(createObject('name', 'github-personal-access-token', 'value', parameters('githubPersonalAccessToken')))), if(empty(parameters('codexAppServerWsBearerToken')), createArray(), createArray(createObject('name', 'codex-app-server-ws-bearer-token', 'value', parameters('codexAppServerWsBearerToken')))))]"
        },
        "template": {
          "containers": [
            {
              "name": "backend",
              "image": "[variables('backendImage')]",
              "resources": {
                "cpu": "[json(parameters('backendResources').cpu)]",
                "memory": "[parameters('backendResources').memory]"
              },
              "env": "[flatten(createArray(createArray(createObject('name', 'ENVIRONMENT', 'value', if(equals(parameters('environmentName'), 'prod'), 'production', 'development')), createObject('name', 'STORAGE_MODE', 'value', parameters('storageMode')), createObject('name', 'LLM_PROVIDER', 'value', parameters('llmProvider')), createObject('name', 'AZURE_OPENAI_ENDPOINT', 'value', if(parameters('createAzureOpenAi'), reference(resourceId('Microsoft.CognitiveServices/accounts', format('{0}-openai-{1}', variables('resourceBaseName'), variables('uniqueSuffix'))), '2024-10-01').endpoint, parameters('azureOpenAiEndpoint'))), createObject('name', 'AZURE_OPENAI_DEPLOYMENT_NAME', 'value', if(parameters('createAzureOpenAi'), parameters('azureOpenAiDeploymentName'), parameters('azureOpenAiDeploymentName'))), createObject('name', 'CODEX_APP_SERVER_TRANSPORT', 'value', parameters('codexAppServerTransport')), createObject('name', 'CODEX_APP_SERVER_COMMAND', 'value', parameters('codexAppServerCommand')), createObject('name', 'CODEX_APP_SERVER_MODEL', 'value', parameters('codexAppServerModel')), createObject('name', 'CODEX_APP_SERVER_TURN_TIMEOUT_MS', 'value', string(parameters('codexAppServerTurnTimeoutMs'))), createObject('name', 'CODEX_APP_SERVER_WS_URL', 'value', parameters('codexAppServerWsUrl')), createObject('name', 'CODEX_APP_SERVER_WS_ALLOW_REMOTE', 'value', if(parameters('codexAppServerWsAllowRemote'), 'true', 'false')), createObject('name', 'COSMOS_DB_ENDPOINT', 'value', if(empty(parameters('cosmosDbEndpointOverride')), reference(resourceId('Microsoft.DocumentDB/databaseAccounts', format('{0}-cosmos-{1}', variables('resourceBaseName'), variables('uniqueSuffix'))), '2024-05-15').documentEndpoint, parameters('cosmosDbEndpointOverride'))), createObject('name', 'COSMOS_DB_DATABASE', 'value', parameters('cosmosDbDatabaseName')), createObject('name', 'KEY_VAULT_URL', 'value', reference(resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName')), '2023-07-01').vaultUri), createObject('name', 'APPLICATIONINSIGHTS_CONNECTION_STRING', 'value', reference(resourceId('Microsoft.Insights/components', format('{0}-insights-{1}', variables('resourceBaseName'), variables('uniqueSuffix'))), '2020-02-02').ConnectionString), createObject('name', 'API_AUTH_KEY', 'secretRef', 'api-auth-key'), createObject('name', 'ADMIN_API_KEY', 'secretRef', 'admin-api-key'), createObject('name', 'AUTH_MODE', 'value', parameters('authMode')), createObject('name', 'ENTRA_TENANT_ID', 'value', parameters('entraTenantId')), createObject('name', 'ENTRA_CLIENT_ID', 'value', parameters('entraClientId')), createObject('name', 'ENTRA_ALLOWED_AUDIENCES', 'value', parameters('entraAllowedAudiences')), createObject('name', 'ENTRA_ADMIN_ROLES', 'value', parameters('entraAdminRoles')), createObject('name', 'GITHUB_WEBHOOK_SECRET', 'secretRef', 'github-webhook-secret')), if(empty(parameters('githubPersonalAccessToken')), createArray(), createArray(createObject('name', 'GITHUB_PERSONAL_ACCESS_TOKEN', 'secretRef', 'github-personal-access-token'))), if(empty(parameters('codexAppServerWsBearerToken')), createArray(), createArray(createObject('name', 'CODEX_APP_SERVER_WS_BEARER_TOKEN', 'secretRef', 'codex-app-server-ws-bearer-token')))))]"
            }
          ],
          "scale": {
            "minReplicas": 0,
            "maxReplicas": 5
          }
        }
      },
      "dependsOn": [
        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('acrPullIdentityName'))]",
        "[extensionResourceId(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), 'Microsoft.Authorization/roleAssignments', guid(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('acrPullIdentityName')), resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), 'acrpull'))]",
        "[resourceId('Microsoft.Insights/components', format('{0}-insights-{1}', variables('resourceBaseName'), variables('uniqueSuffix')))]",
        "[resourceId('Microsoft.App/managedEnvironments', parameters('containerAppsEnvironmentName'))]",
        "[resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName'))]",
        "[resourceId('Microsoft.DocumentDB/databaseAccounts', format('{0}-cosmos-{1}', variables('resourceBaseName'), variables('uniqueSuffix')))]",
        "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
        "[resourceId('Microsoft.CognitiveServices/accounts/deployments', format('{0}-openai-{1}', variables('resourceBaseName'), variables('uniqueSuffix')), parameters('azureOpenAiDeploymentName'))]",
        "[resourceId('Microsoft.CognitiveServices/accounts', format('{0}-openai-{1}', variables('resourceBaseName'), variables('uniqueSuffix')))]"
      ]
    },
    {
      "type": "Microsoft.App/containerApps",
      "apiVersion": "2024-03-01",
      "name": "[parameters('frontendContainerAppName')]",
      "location": "[parameters('location')]",
      "identity": {
        "type": "SystemAssigned,UserAssigned",
        "userAssignedIdentities": {
          "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('acrPullIdentityName')))]": {}
        }
      },
      "properties": {
        "managedEnvironmentId": "[resourceId('Microsoft.App/managedEnvironments', parameters('containerAppsEnvironmentName'))]",
        "configuration": {
          "ingress": {
            "external": true,
            "targetPort": 3000,
            "transport": "auto"
          },
          "registries": [
            {
              "server": "[reference(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), '2023-07-01').loginServer]",
              "identity": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('acrPullIdentityName'))]"
            }
          ],
          "secrets": [
            {
              "name": "api-auth-key",
              "value": "[parameters('apiAuthKey')]"
            }
          ]
        },
        "template": {
          "containers": [
            {
              "name": "frontend",
              "image": "[variables('frontendImage')]",
              "resources": {
                "cpu": "[json(parameters('frontendResources').cpu)]",
                "memory": "[parameters('frontendResources').memory]"
              },
              "env": "[flatten(createArray(createArray(createObject('name', 'BACKEND_UPSTREAM', 'value', format('https://{0}', reference(resourceId('Microsoft.App/containerApps', parameters('backendContainerAppName')), '2024-03-01').configuration.ingress.fqdn))), if(equals(parameters('frontendAuthMode'), 'entra'), createArray(createObject('name', 'API_AUTH_KEY', 'value', 'disabled')), createArray(createObject('name', 'API_AUTH_KEY', 'secretRef', 'api-auth-key'))), createArray(createObject('name', 'VITE_AUTH_MODE', 'value', parameters('frontendAuthMode')), createObject('name', 'VITE_ENTRA_TENANT_ID', 'value', parameters('frontendEntraTenantId')), createObject('name', 'VITE_ENTRA_CLIENT_ID', 'value', parameters('frontendEntraClientId')), createObject('name', 'VITE_ENTRA_AUTHORITY', 'value', parameters('frontendEntraAuthority')), createObject('name', 'VITE_ENTRA_API_SCOPE', 'value', parameters('frontendEntraApiScope')), createObject('name', 'VITE_ENTRA_REDIRECT_URI', 'value', parameters('frontendEntraRedirectUri')), createObject('name', 'VITE_ENTRA_POST_LOGOUT_REDIRECT_URI', 'value', parameters('frontendEntraPostLogoutRedirectUri')))))]"
            }
          ],
          "scale": {
            "minReplicas": 0,
            "maxReplicas": 3
          }
        }
      },
      "dependsOn": [
        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('acrPullIdentityName'))]",
        "[extensionResourceId(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), 'Microsoft.Authorization/roleAssignments', guid(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('acrPullIdentityName')), resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), 'acrpull'))]",
        "[resourceId('Microsoft.App/containerApps', parameters('backendContainerAppName'))]",
        "[resourceId('Microsoft.App/managedEnvironments', parameters('containerAppsEnvironmentName'))]",
        "[resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName'))]"
      ]
    },
    {
      "condition": "[parameters('createCosmosDb')]",
      "type": "Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments",
      "apiVersion": "2024-05-15",
      "name": "[format('{0}/{1}', format('{0}-cosmos-{1}', variables('resourceBaseName'), variables('uniqueSuffix')), guid(resourceId('Microsoft.App/containerApps', parameters('backendContainerAppName')), resourceId('Microsoft.DocumentDB/databaseAccounts', format('{0}-cosmos-{1}', variables('resourceBaseName'), variables('uniqueSuffix'))), 'cosmos-contributor'))]",
      "properties": {
        "roleDefinitionId": "[format('{0}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002', resourceId('Microsoft.DocumentDB/databaseAccounts', format('{0}-cosmos-{1}', variables('resourceBaseName'), variables('uniqueSuffix'))))]",
        "principalId": "[reference(resourceId('Microsoft.App/containerApps', parameters('backendContainerAppName')), '2024-03-01', 'full').identity.principalId]",
        "scope": "[resourceId('Microsoft.DocumentDB/databaseAccounts', format('{0}-cosmos-{1}', variables('resourceBaseName'), variables('uniqueSuffix')))]"
      },
      "dependsOn": [
        "[resourceId('Microsoft.App/containerApps', parameters('backendContainerAppName'))]",
        "[resourceId('Microsoft.DocumentDB/databaseAccounts', format('{0}-cosmos-{1}', variables('resourceBaseName'), variables('uniqueSuffix')))]"
      ]
    },
    {
      "type": "Microsoft.Authorization/roleAssignments",
      "apiVersion": "2022-04-01",
      "scope": "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
      "name": "[guid(resourceId('Microsoft.App/containerApps', parameters('backendContainerAppName')), resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName')), 'keyvault-secrets')]",
      "properties": {
        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')]",
        "principalId": "[reference(resourceId('Microsoft.App/containerApps', parameters('backendContainerAppName')), '2024-03-01', 'full').identity.principalId]",
        "principalType": "ServicePrincipal"
      },
      "dependsOn": [
        "[resourceId('Microsoft.App/containerApps', parameters('backendContainerAppName'))]",
        "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
      ]
    },
    {
      "condition": "[parameters('createAzureOpenAi')]",
      "type": "Microsoft.Authorization/roleAssignments",
      "apiVersion": "2022-04-01",
      "scope": "[resourceId('Microsoft.CognitiveServices/accounts', format('{0}-openai-{1}', variables('resourceBaseName'), variables('uniqueSuffix')))]",
      "name": "[guid(resourceId('Microsoft.App/containerApps', parameters('backendContainerAppName')), resourceId('Microsoft.CognitiveServices/accounts', format('{0}-openai-{1}', variables('resourceBaseName'), variables('uniqueSuffix'))), 'openai-user')]",
      "properties": {
        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd')]",
        "principalId": "[reference(resourceId('Microsoft.App/containerApps', parameters('backendContainerAppName')), '2024-03-01', 'full').identity.principalId]",
        "principalType": "ServicePrincipal"
      },
      "dependsOn": [
        "[resourceId('Microsoft.App/containerApps', parameters('backendContainerAppName'))]",
        "[resourceId('Microsoft.CognitiveServices/accounts', format('{0}-openai-{1}', variables('resourceBaseName'), variables('uniqueSuffix')))]"
      ]
    }
  ],
  "outputs": {
    "acrName": {
      "type": "string",
      "value": "[parameters('acrName')]"
    },
    "acrLoginServer": {
      "type": "string",
      "value": "[reference(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), '2023-07-01').loginServer]"
    },
    "backendAppName": {
      "type": "string",
      "value": "[parameters('backendContainerAppName')]"
    },
    "backendUrl": {
      "type": "string",
      "value": "[format('https://{0}', reference(resourceId('Microsoft.App/containerApps', parameters('backendContainerAppName')), '2024-03-01').configuration.ingress.fqdn)]"
    },
    "frontendAppName": {
      "type": "string",
      "value": "[parameters('frontendContainerAppName')]"
    },
    "frontendUrl": {
      "type": "string",
      "value": "[format('https://{0}', reference(resourceId('Microsoft.App/containerApps', parameters('frontendContainerAppName')), '2024-03-01').configuration.ingress.fqdn)]"
    },
    "openAiEndpoint": {
      "type": "string",
      "value": "[if(parameters('createAzureOpenAi'), reference(resourceId('Microsoft.CognitiveServices/accounts', format('{0}-openai-{1}', variables('resourceBaseName'), variables('uniqueSuffix'))), '2024-10-01').endpoint, parameters('azureOpenAiEndpoint'))]"
    },
    "cosmosDbEndpoint": {
      "type": "string",
      "value": "[if(empty(parameters('cosmosDbEndpointOverride')), reference(resourceId('Microsoft.DocumentDB/databaseAccounts', format('{0}-cosmos-{1}', variables('resourceBaseName'), variables('uniqueSuffix'))), '2024-05-15').documentEndpoint, parameters('cosmosDbEndpointOverride'))]"
    },
    "keyVaultUrl": {
      "type": "string",
      "value": "[reference(resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName')), '2023-07-01').vaultUri]"
    },
    "appInsightsConnectionString": {
      "type": "string",
      "value": "[reference(resourceId('Microsoft.Insights/components', format('{0}-insights-{1}', variables('resourceBaseName'), variables('uniqueSuffix'))), '2020-02-02').ConnectionString]"
    }
  }
}\n- both Bicep parameter files compiled with the expected dev and prod resource pairs\n- Azure deployment validation succeeded against the existing dev resource group\n- an invalid 0.5 vCPU / 2 GiB pair was rejected by ARM validation\n- backend tests: 422 passed\n- existing dev images and  remained unchanged\n- dev health checks returned HTTP 200 with version 0.9.0 after rightsizing\n- rollback to the previous allocations was applied and health-checked, then the canary allocations were restored\n\n## Deployment note\n\nThe full resource-group what-if included unrelated infrastructure drift, so it was not applied. The live canary used targeted Container Apps resource updates only. No production or registry resources were changed.