### PR TITLE
docs(azure): record ACA dev rightsizing rollout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PipelineHealer
 
-<!-- LAST_VERIFIED: 4641044 -->
+<!-- LAST_VERIFIED: 5ddcb13 -->
 
 > Agent control plane for failed delivery pipelines.
 
@@ -145,6 +145,13 @@ Steps:
 ## Azure Container Apps Deploy
 
 The reference deployment uses `scripts/ph.sh`, Azure Container Registry, and Azure Container Apps.
+
+The Bicep reference sizes development at 0.5 vCPU / 1 GiB for the backend and
+0.25 vCPU / 0.5 GiB for the frontend. Production stays at 1 vCPU / 2 GiB for
+the backend and 0.5 vCPU / 1 GiB for the frontend. Both use `minReplicas=0`, so
+idle cost is lower but the first request after scale-to-zero can take tens of
+seconds. See [Azure Container Apps Resource Sizing](docs/runbooks/ACA_RESOURCE_SIZING.md)
+for allowed CPU/memory pairs, validation, cold-start proof, and rollback.
 
 Set your Azure target explicitly. The public CLI does not carry maintainer production names:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Docs Index
 
-<!-- LAST_VERIFIED: 3b278e7 -->
+<!-- LAST_VERIFIED: 5ddcb13 -->
 
 Use this index to find the canonical doc quickly. If a topic appears in both an active doc and `docs/archive/`, the active doc wins.
 
@@ -25,6 +25,7 @@ If you are validating the runtime configuration model specifically, start with:
 - `runbooks/DEMO_SCRIPT.md` - concise recording and narration guide
 - `runbooks/LIFECYCLE_E2E_VERIFICATION.md` - artifact lifecycle loop verification (markers, dedup, green-close)
 - `runbooks/LOCAL_DEMO_RUNBOOK.md` - end-to-end local and Azure operator runbook
+- `runbooks/ACA_RESOURCE_SIZING.md` - ACA dev/prod CPU and memory contract, validation, cold-start evidence, and rollback
 - `runbooks/LOGS_AND_INVESTIGATION.md` - troubleshooting and evidence collection guide
 - `runbooks/KUBERNETES_HELM_RUNBOOK.md` - secondary Helm/Kubernetes deployment path
 - `runbooks/RELEASE_RUNBOOK.md` - release prep, publish, verify, and rollback

--- a/docs/runbooks/ACA_RESOURCE_SIZING.md
+++ b/docs/runbooks/ACA_RESOURCE_SIZING.md
@@ -1,0 +1,158 @@
+# Azure Container Apps Resource Sizing
+
+<!-- LAST_VERIFIED: 5ddcb13 -->
+
+This runbook defines the CPU, memory, and scale-to-zero contract for the
+PipelineHealer Azure Container Apps reference deployment. The Bicep parameter
+files are the source of truth. Live resource values must be checked separately
+because an operator can apply a targeted Container Apps update without changing
+the repository.
+
+## Environment Contract
+
+| Environment | Parameter file | App | CPU | Memory | Minimum replicas |
+| --- | --- | --- | ---: | ---: | ---: |
+| Development | `infra/main.bicepparam` | Backend | 0.5 vCPU | 1 GiB | 0 |
+| Development | `infra/main.bicepparam` | Frontend | 0.25 vCPU | 0.5 GiB | 0 |
+| Production | `infra/main.prod.bicepparam` | Backend | 1 vCPU | 2 GiB | 0 |
+| Production | `infra/main.prod.bicepparam` | Frontend | 0.5 vCPU | 1 GiB | 0 |
+
+`infra/main.bicep` keeps the backend maximum at 5 replicas and the frontend
+maximum at 3 replicas. The production values above preserve the allocations
+that existed before the development rightsizing change. They are an IaC
+contract, not proof that the current production apps match the template.
+
+## Validation Rules
+
+The backend and frontend each accept one complete Consumption-plan resource
+object. CPU and memory cannot be chosen independently. The allowed pairs are:
+
+| CPU | Memory |
+| ---: | ---: |
+| 0.25 vCPU | 0.5 GiB |
+| 0.5 vCPU | 1 GiB |
+| 0.75 vCPU | 1.5 GiB |
+| 1 vCPU | 2 GiB |
+| 1.25 vCPU | 2.5 GiB |
+| 1.5 vCPU | 3 GiB |
+| 1.75 vCPU | 3.5 GiB |
+| 2 vCPU | 4 GiB |
+
+The Bicep `@allowed` constraint compares the complete object. A mixed pair such
+as 0.5 vCPU with 2 GiB is invalid and must fail validation before deployment.
+Keep the CPU values as strings in the parameter files. The template converts
+CPU to the numeric ARM value when it builds each Container App resource.
+
+Run these checks before a resource change:
+
+```bash
+az bicep build --file infra/main.bicep --stdout >/dev/null
+az bicep build-params --file infra/main.bicepparam --stdout >/dev/null
+
+infisical run --env prod --path /pipelinehealer/prod --projectId <infisical-project-id> -- \
+  az bicep build-params --file infra/main.prod.bicepparam --stdout >/dev/null
+```
+
+The production parameter file requires secret environment variables while it
+compiles. Use the approved secret source and keep compiled output out of logs.
+Validate and preview against the intended environment before applying:
+
+```bash
+az deployment group validate \
+  --resource-group "$PH_RG" \
+  --template-file infra/main.bicep \
+  --parameters infra/main.bicepparam
+
+az deployment group what-if \
+  --resource-group "$PH_RG" \
+  --template-file infra/main.bicep \
+  --parameters infra/main.bicepparam
+```
+
+Use `infra/main.prod.bicepparam` only for a production review. Do not apply a
+full resource-group deployment when `what-if` includes unrelated drift.
+
+## Scale-to-Zero Tradeoff
+
+`minReplicas=0` reduces idle compute cost. The first request after both apps
+reach zero replicas pays a cold-start delay, so run `bash scripts/ph.sh warm`
+before a timed demo and `bash scripts/ph.sh lowcost` afterward.
+
+The completed development canary produced this single observation from
+confirmed zero replicas:
+
+- Backend `/health`: HTTP 200, `healthy`, version `0.9.0`, in 29.829 seconds.
+- Frontend: HTTP 200 in 21.686 seconds.
+- Both apps later reported `Healthy`, `ScaledToZero`, and 0 replicas.
+
+These timings show the cost and viability of scale-to-zero at the approved dev
+sizes. They are not a latency SLO, load test, percentile, or production
+benchmark. Frontend HTTP 200 proves that the frontend served a response; it
+does not by itself prove backend readiness or an end-to-end remediation flow.
+
+## Rollback
+
+The last known dev allocation before rightsizing was:
+
+| App | CPU | Memory |
+| --- | ---: | ---: |
+| Backend | 1 vCPU | 2 GiB |
+| Frontend | 0.5 vCPU | 1 GiB |
+
+For a normal rollback:
+
+1. Revert the dev pairs in `infra/main.bicepparam` in a reviewed commit.
+2. Rebuild both the template and parameter file, then run ARM validation.
+3. Run `az deployment group what-if` and confirm that only the intended
+   Container Apps resource values will change.
+4. Apply the deployment, verify both resource pairs, and health-check the
+   backend and frontend.
+5. Confirm the apps can return to `Healthy`, `ScaledToZero`, and 0 replicas.
+
+If the full resource-group preview contains unrelated drift, do not apply it.
+Restore only the two Container App resource pairs:
+
+```bash
+az containerapp update \
+  --resource-group "$PH_RG" \
+  --name "$PH_BACKEND_APP" \
+  --cpu 1 \
+  --memory 2Gi
+
+az containerapp update \
+  --resource-group "$PH_RG" \
+  --name "$PH_FRONTEND_APP" \
+  --cpu 0.5 \
+  --memory 1Gi
+```
+
+After an emergency targeted rollback, align `infra/main.bicepparam` in a
+follow-up PR so the next full deployment cannot silently restore the rejected
+sizes. Do not change images, environment variables, replica limits, production,
+or registry state as part of a resource-only rollback.
+
+## Verification and Proof Boundary
+
+The development rightsizing rollout landed through
+[PR #236](https://github.com/Canepro/pipelinehealer/pull/236) and merged as
+`5ddcb13ac7a854fe04a68bed6d57baa6620ff1f9`.
+
+Verified for that rollout:
+
+- `infra/main.bicep` built successfully.
+- The dev and production parameter files compiled with their expected pairs.
+- ARM validation succeeded against the existing dev resource group.
+- ARM rejected an invalid 0.5 vCPU / 2 GiB pair.
+- The backend suite passed 422 tests.
+- All four PR CI jobs passed: ShellCheck Scripts, Version Sync, Backend Tests
+  and Types, and Frontend Lint and Build.
+- The live dev backend and frontend passed the cold-start checks above.
+- The prior dev pairs were restored and health-checked as a rollback exercise,
+  then the approved canary pairs were restored.
+- Dev retained `minReplicas=0`, and both apps returned to zero replicas.
+
+The full resource-group `what-if` contained unrelated infrastructure drift, so
+it was not applied. The live canary and rollback used targeted Container Apps
+resource updates. Production allocations and images were unchanged. No
+production deployment, production cold-start test, ACR mutation, or application
+code change is covered by this proof.

--- a/docs/runbooks/LOCAL_DEMO_RUNBOOK.md
+++ b/docs/runbooks/LOCAL_DEMO_RUNBOOK.md
@@ -1,6 +1,6 @@
 # Local Demo Runbook (PipelineHealer)
 
-<!-- LAST_VERIFIED: b619406 -->
+<!-- LAST_VERIFIED: 5ddcb13 -->
 
 This guide walks you through setting up PipelineHealer locally, triggering CI failures in a demo repo, and verifying the results on the dashboard.
 
@@ -823,6 +823,14 @@ bash scripts/ph.sh deploy:env --secure-secrets
 ### Scale To Zero
 
 Azure Container Apps can scale down to 0 instances when idle to save cost. This means the first request after a period of inactivity may be slow (cold start).
+
+The current dev contract is 0.5 vCPU / 1 GiB for the backend and 0.25 vCPU /
+0.5 GiB for the frontend, with `minReplicas=0` on both. A confirmed
+scale-from-zero check returned backend health in 29.829 seconds and the frontend
+in 21.686 seconds. Treat these as one dev observation, not a latency SLO or
+production benchmark. The allowed resource pairs, validation steps, proof
+boundary, and resource-only rollback are in
+[Azure Container Apps Resource Sizing](ACA_RESOURCE_SIZING.md).
 
 ```bash
 bash scripts/ph.sh warm     # keep apps running (before demos)


### PR DESCRIPTION
## Summary

- add the canonical ACA resource sizing and rollback runbook
- document the dev and production IaC pairs and validation rules
- record the observed dev cold-start tradeoff and proof boundary
- link the contract from the README, docs index, and local demo runbook

## Verification

- git diff --cached --check
- bash scripts/check_version_sync.sh
- az bicep build for infra/main.bicep
- az bicep build-params for dev and prod parameter files; prod used compile-only placeholder env values and emitted no compiled output
- confirmed documented az containerapp update flags from local CLI help

## Boundary

Documentation only. No Azure resource, production, ACR, image, secret, or application-code change.